### PR TITLE
Open api fixes

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,20 @@
+# This workflow will do a clean install of node dependencies, cache/restore them, build the source code and run tests across different versions of node
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+
+name: Node.js CI
+
+on: [push, workflow_dispatch]
+  
+jobs:
+  validateOpenApiSpec:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js
+      uses: actions/setup-node@v2
+      with:
+        node-version: 12
+    - run: npm install -g ibm-openapi-validator
+    - run: lint-openapi openapi.yaml

--- a/.validaterc
+++ b/.validaterc
@@ -1,0 +1,109 @@
+{
+  "shared": {
+    "operations": {
+      "no_operation_id": "warning",
+      "operation_id_case_convention": [
+        "warning",
+        "lower_snake_case"
+      ],
+      "no_summary": "warning",
+      "no_array_responses": "error",
+      "parameter_order": "warning",
+      "undefined_tag": "warning",
+      "unused_tag": "warning",
+      "operation_id_naming_convention": "warning"
+    },
+    "pagination": {
+      "pagination_style": "warning"
+    },
+    "parameters": {
+      "no_parameter_description": "error",
+      "param_name_case_convention": [
+        "error",
+        "lower_snake_case"
+      ],
+      "invalid_type_format_pair": "error",
+      "content_type_parameter": "error",
+      "accept_type_parameter": "error",
+      "authorization_parameter": "warning",
+      "required_param_has_default": "warning"
+    },
+    "paths": {
+      "missing_path_parameter": "error",
+      "duplicate_path_parameter": "warning",
+      "snake_case_only": "off",
+      "paths_case_convention": [
+        "error",
+        "lower_snake_case"
+      ]
+    },
+    "responses": {
+      "inline_response_schema": "warning"
+    },
+    "security_definitions": {
+      "unused_security_schemes": "warning",
+      "unused_security_scopes": "warning"
+    },
+    "security": {
+      "invalid_non_empty_security_array": "error"
+    },
+    "schemas": {
+      "invalid_type_format_pair": "error",
+      "snake_case_only": "off",
+      "no_schema_description": "warning",
+      "no_property_description": "warning",
+      "description_mentions_json": "warning",
+      "array_of_arrays": "warning",
+      "inconsistent_property_type": [
+        "warning",
+        [
+          "code",
+          "default",
+          "type",
+          "value"
+        ]
+      ],
+      "property_case_convention": [
+        "error",
+        "lower_snake_case"
+      ],
+      "property_case_collision": "error",
+      "enum_case_convention": [
+        "warning",
+        "lower_snake_case"
+      ],
+      "undefined_required_properties": "warning"
+    },
+    "walker": {
+      "no_empty_descriptions": "error",
+      "has_circular_references": "warning",
+      "$ref_siblings": "off",
+      "duplicate_sibling_description": "warning",
+      "incorrect_ref_pattern": "warning"
+    }
+  },
+  "swagger2": {
+    "operations": {
+      "no_consumes_for_put_or_post": "error",
+      "get_op_has_consumes": "warning",
+      "no_produces": "warning"
+    }
+  },
+  "oas3": {
+    "operations": {
+      "no_request_body_name": "warning"
+    },
+    "responses": {
+      "no_success_response_codes": "warning",
+      "protocol_switching_and_success_code": "error",
+      "no_response_body": "warning",
+      "ibm_status_code_guidelines": "warning"
+    },
+    "schemas": {
+      "json_or_param_binary_string": "warning"
+    }
+  },
+  "spectral": {
+    "rules": {}
+  }
+}

--- a/.validaterc
+++ b/.validaterc
@@ -20,7 +20,7 @@
       "no_parameter_description": "error",
       "param_name_case_convention": [
         "error",
-        "lower_snake_case"
+        "lower_camel_case"
       ],
       "invalid_type_format_pair": "error",
       "content_type_parameter": "error",
@@ -65,7 +65,7 @@
       ],
       "property_case_convention": [
         "error",
-        "lower_snake_case"
+        "lower_camel_case"
       ],
       "property_case_collision": "error",
       "enum_case_convention": [

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,5 +1,5 @@
-openapi: "3.0.0"
-
+$schema: “https://spec.openapis.org/oas/3.1/dialect/base”
+openapi: "3.1.0"
 info:
   title: HDF Scalable Data Service REST API
   description: RESTful application programming interface documentation for HDF Scalable Data Service (HSDS).
@@ -64,21 +64,21 @@ components:
       properties:
         forWhom:
           $ref: "#/components/schemas/ACL"
-      example:
-        test_user1:
-          create: true
-          update: true
-          delete: true
-          updateACL: true
-          read: true
-          readACL: true
-        default:
-          create: false
-          update: false
-          delete: false
-          updateACL: false
-          read: true
-          readACL: false
+      examples:
+        - test_user1:
+            create: true
+            update: true
+            delete: true
+            updateACL: true
+            read: true
+            readACL: true
+          default:
+            create: false
+            update: false
+            delete: false
+            updateACL: false
+            read: true
+            readACL: false
 
   parameters:
     authorization:
@@ -199,19 +199,23 @@ paths:
                   created:
                     description: When domain was created.
                     type: number
-                    example: 1521482043.5271084
+                    examples:
+                      - 1521482043.5271084
                   lastModified:
                     description: When object was last modified.
                     type: number
-                    example: 1521482043.5271084
+                    examples:
+                      - 1521482043.5271084
                   owner:
                     description: Name of owner.
                     type: string
-                    example: "test_user1"
+                    examples:
+                      - "test_user1"
                   root:
                     description: ID of root group.
                     type: string
-                    example: "g-82da0346-2b9e-11e8-9391-0242ac110009"
+                    examples:
+                      - "g-82da0346-2b9e-11e8-9391-0242ac110009"
         default:
           description: Operation unsuccessful.
 
@@ -256,10 +260,12 @@ paths:
                       UUID of root Group.
                       If Domain is of class 'folder', this entry is not present.
                     type: string
-                    example: "g-82da0346-2b9e-11e8-9391-0242ac110009"
+                    examples:
+                      - "g-82da0346-2b9e-11e8-9391-0242ac110009"
                   owner:
                     type: string
-                    example: "test_user1"
+                    examples:
+                      - "test_user1"
                   class:
                     description: >
                       Category of Domain.
@@ -268,13 +274,16 @@ paths:
                     enum:
                       - domain
                       - folder
-                    example: domain
+                    examples:
+                      - domain
                   created:
                     type: number
-                    example: 1521476710.039304
+                    examples:
+                      - 1521476710.039304
                   lastModified:
                     type: number
-                    example: 1521476710.039304
+                    examples:
+                      - 1521476710.039304
                   hrefs:
                     description: >
                       Array of url references and their relation to this Domain.
@@ -296,7 +305,7 @@ paths:
                         rel:
                           description: Relation to this Domain.
                           type: string
-                    example:
+                    examples:
                       - rel: acls
                         href: "http://myfile.test_user1.home/acls"
                       - rel: database
@@ -356,7 +365,8 @@ paths:
                   domain:
                     type: string
                     description: domain path
-                    example: "/home/test_user/some_path/some_file"
+                    examples:
+                      - "/home/test_user/some_path/some_file"
         default:
           description: Operation unsuccessful.
 
@@ -409,11 +419,13 @@ paths:
                     id:
                       description: "UUID of Group to link from."
                       type: string
-                      example: "g-a613ed48-2c86-11e8-9391-0242ac110009"
+                      examples:
+                        - "g-a613ed48-2c86-11e8-9391-0242ac110009"
                     name:
                       description: Title of Link.
                       type: string
-                      example: "g2"
+                      examples:
+                        - "g2"
       responses:
         "201":
           description: New Group created.
@@ -434,23 +446,29 @@ paths:
                   id:
                     description: UUID of new Group.
                     type: string
-                    example: "g-a613ed48-2c86-11e8-9391-0242ac110009"
+                    examples:
+                      - "g-a613ed48-2c86-11e8-9391-0242ac110009"
                   root:
                     description: UUID of root Group in Domain.
                     type: string
-                    example: "g-37aa76f6-2c86-11e8-9391-0242ac110009"
+                    examples:
+                      - "g-37aa76f6-2c86-11e8-9391-0242ac110009"
                   lastModified:
                     type: number
-                    example: 1521581745.9365487
+                    examples:
+                      - 1521581745.9365487
                   created:
                     type: number
-                    example: 1521581745.9365487
+                    examples:
+                      - 1521581745.9365487
                   attributeCount:
                     type: number
-                    example: 0
+                    examples:
+                      - 0
                   linkCount:
                     type: number
-                    example: 0
+                    examples:
+                      - 0
         default:
           description: Operation unsuccessful.
 
@@ -496,7 +514,7 @@ paths:
                     items:
                       description: UUID of each Group.
                       type: string
-                    example:
+                    examples:
                       - "g-a613ed48-2c86-11e8-9391-0242ac110009"
                       - "g-37aa76f6-2c86-11e8-9391-0242ac110009"
                   hrefs:
@@ -519,7 +537,7 @@ paths:
                         rel:
                           description: Relation to this object.
                           type: string
-                    example:
+                    examples:
                       - rel: "attributes"
                         href: "http://localhost:5101/groups/g-ee2f6a2c-3847-11e8-a123-0242ac110009/attributes?domain=/home/test_user1/file"
                       - rel: "home"
@@ -581,11 +599,13 @@ paths:
                   id:
                     description: UUID of this Group.
                     type: string
-                    example: g-37aa76f6-2c86-11e8-9391-0242ac110009
+                    examples:
+                      - g-37aa76f6-2c86-11e8-9391-0242ac110009
                   root:
                     description: UUID of root Group.
                     type: string
-                    example: g-37aa76f6-2c86-11e8-9391-0242ac110009
+                    examples:
+                      - g-37aa76f6-2c86-11e8-9391-0242ac110009
                   alias:
                     description: >
                       List of aliases for the Group, as reached by _hard_ Links.
@@ -595,22 +615,28 @@ paths:
                     type: array
                     items:
                       type: string
-                    example: ["/g1/g1.1"]
+                    examples:
+                      - ["/g1/g1.1"]
                   created:
                     type: number
-                    example: 1521581560.6883142
+                    examples:
+                      - 1521581560.6883142
                   lastModified:
                     type: number
-                    example: 1521644498.984212
+                    examples:
+                      - 1521644498.984212
                   domain:
                     type: string
-                    example: "/home/test_user1/file"
+                    examples:
+                      - "/home/test_user1/file"
                   attributeCount:
                     type: number
-                    example: 4
+                    examples:
+                      - 4
                   linkCount:
                     type: number
-                    example: 2
+                    examples:
+                      - 2
                   hrefs:
                     description: List of references to other objects.
                     type: array
@@ -629,12 +655,14 @@ paths:
                         rel:
                           description: Relation to this object.
                           type: string
-                          example: "self"
+                          examples:
+                            - "self"
                         href:
                           description: URL to reference.
                           type: string
-                          example: "http://myfile.test_user1.home/"
-                    example:
+                          examples:
+                            - "http://myfile.test_user1.home/"
+                    examples:
                       - rel: "attributes"
                         href: "http://localhost:5101/groups/g-37aa76f6-2c86-11e8-9391-0242ac110009/attributes?domain=/home/test_user1/file"
                       - rel: "home"
@@ -730,10 +758,12 @@ paths:
                         id:
                           description: UUID of Link target.
                           type: string
-                          example: "g-a613ed48-2c86-11e8-9391-0242ac110009"
+                          examples:
+                            - "g-a613ed48-2c86-11e8-9391-0242ac110009"
                         created:
                           type: number
-                          example: 1521644498.984212
+                          examples:
+                            - 1521644498.984212
                         class:
                           description: >
                             Indicate whether this Link is hard, soft, or
@@ -743,21 +773,27 @@ paths:
                             - "H5L_TYPE_HARD"
                             - "H5L_TYPE_SOFT"
                             - "H5L_TYPE_EXTERNAL"
-                          example: "H5L_TYPE_HARD"
+                          examples:
+                            - "H5L_TYPE_HARD"
+                            - "H5L_TYPE_SOFT"
+                            - "H5L_TYPE_EXTERNAL"
                         title:
                           description: >
                             Name/label/title of the Link, as provided upon
                             creation.
                           type: string
-                          example: "g1"
+                          examples:
+                            - "g1"
                         target:
                           description: URL of Link target.
                           type: string
-                          example: "http://localhost:5101/groups/g-a613ed48-2c86-11e8-9391-0242ac110009?domain=/home/test_user1/file"
+                          examples:
+                            - "http://localhost:5101/groups/g-a613ed48-2c86-11e8-9391-0242ac110009?domain=/home/test_user1/file"
                         href:
                           description: URL to origin of Link.
                           type: string
-                          example: "http://localhost:5101/groups/g-37aa76f6-2c86-11e8-9391-0242ac110009/links/g1?domain=/home/test_user1/file"
+                          examples:
+                            - "http://localhost:5101/groups/g-37aa76f6-2c86-11e8-9391-0242ac110009/links/g1?domain=/home/test_user1/file"
                         collection:
                           description: >
                             What kind of object is the target. (TODO)
@@ -767,7 +803,9 @@ paths:
                             - "datasets"
                           #  - 'datatypes' TODO
                           #  - 'attributes' TODO
-                          example: "groups"
+                          examples:
+                            - "groups"
+                            - "datasets"
                   hrefs:
                     type: array
                     description: >
@@ -786,7 +824,7 @@ paths:
                         href:
                           description: URL to reference.
                           type: string
-                    example:
+                    examples:
                       - rel: home
                         href': http://localhost:5101/?domain=/home/test_user1/file
                       - rel: owner
@@ -845,7 +883,8 @@ paths:
 
                     Overrides other fields.
                   type: string
-                  example: "g-37aa76f6-2c86-11e8-9391-0242ac110009"
+                  examples:
+                    - "g-37aa76f6-2c86-11e8-9391-0242ac110009"
                 h5path:
                   description: >
                     Path to an object relative to a Domain's root.
@@ -858,7 +897,8 @@ paths:
 
                     If used, will create a soft or external Link.
                   type: string
-                  example: "/dset1"
+                  examples:
+                    - "/dset1"
                 h5domain:
                   description: >
                     URL of external domain.
@@ -867,7 +907,8 @@ paths:
 
                     Requires `h5path` be present.
                   type: string
-                  example: "external_target.test.hdfgroup.org"
+                  examples:
+                    - "external_target.test.hdfgroup.org"
       responses:
         "201":
           description: New Link created.
@@ -876,8 +917,8 @@ paths:
               schema:
                 type: object
                 description: 'Always returns `{"hrefs": []}`.'
-                example:
-                  hrefs: []
+                examples:
+                  - hrefs: []
         default:
           description: Operation unsuccessful.
 
@@ -909,16 +950,20 @@ paths:
                     properties:
                       id:
                         type: string
-                        example: "g-a613ed48-2c86-11e8-9391-0242ac110009"
+                        examples:
+                          - "g-a613ed48-2c86-11e8-9391-0242ac110009"
                       title:
                         type: string
-                        example: "g1"
+                        examples:
+                          - "g1"
                       collection:
                         type: string
-                        example: "group"
+                        examples:
+                          - "group"
                       class:
                         type: string
-                        example: "H5L_TYPE_HARD"
+                        examples:
+                          - "H5L_TYPE_HARD"
                   hrefs:
                     type: array
                     description: >
@@ -938,7 +983,7 @@ paths:
                         rel:
                           description: Relation to this object.
                           type: string
-                    example:
+                    examples:
                       - rel: "home"
                         href: "http://localhost:5101/?domain=/home/test_user1/file"
                       - rel: "owner"
@@ -969,8 +1014,8 @@ paths:
               schema:
                 type: object
                 description: 'Always returns `{"hrefs": []}`.'
-                example:
-                  href: []
+                examples:
+                  - href: []
         default:
           description: Operation unsuccessful.
 
@@ -1034,7 +1079,8 @@ paths:
                     For now, see:
                     http://h5serv.readthedocs.io/en/latest/Types/index.html
                   type: string # TODO: ambiguous string or object
-                  example: "H5T_STD_U32LE"
+                  examples:
+                    - "H5T_STD_U32LE"
                 shape:
                   description: >
                     Either an integer array giving the initial dimensions of
@@ -1050,7 +1096,8 @@ paths:
                     If `shape` is omitted or empty (`[]`), will create a scalar
                     dataset -- dataset comprised of a single entity.
                   type: string
-                  example: [128, 64]
+                  examples:
+                    - [128, 64]
                 maxdims:
                   description: >
                     Integer array diving the maximum allowed extent for each
@@ -1061,7 +1108,8 @@ paths:
                   type: array
                   items:
                     type: number
-                  example: [0, 512]
+                  examples:
+                    - [0, 512]
                 creationProperties:
                   description: TODO
                   type: object
@@ -1084,11 +1132,13 @@ paths:
                     id:
                       description: "UUID of Group to link from."
                       type: string
-                      example: "g-a613ed48-2c86-11e8-9391-0242ac110009"
+                      examples:
+                        - "g-a613ed48-2c86-11e8-9391-0242ac110009"
                     name:
                       description: Title of Link.
                       type: string
-                      example: "dset2"
+                      examples:
+                        - "dset2"
       responses:
         "201":
           description: Dataset created.
@@ -1115,17 +1165,13 @@ paths:
                   shape:
                     description: (See `GET /datasets/{id}`)
                     type: object
-        default:
-          description: Operation unsuccessful.
 
     get:
       tags:
         - Domain
         - Dataset
       summary: List Datasets.
-      description: >
-        Only includes Datasets that are part of the tree linked to the root
-        Group in the Domain.
+      description: Only includes Datasets that are part of the tree linked to the root  Group in the Domain.
       parameters:
         - $ref: "#/components/parameters/query_domain"
         - $ref: "#/components/parameters/authorization"
@@ -1142,7 +1188,8 @@ paths:
                     items:
                       description: UUID of each Dataset.
                       type: string
-                      example: "d-21ae0bbe-2dea-11e8-9391-0242ac110009"
+                      examples:
+                        - "d-21ae0bbe-2dea-11e8-9391-0242ac110009"
                   hrefs:
                     type: array
                     description: >
@@ -1163,7 +1210,7 @@ paths:
                         rel:
                           description: Relation to this object.
                           type: string
-                    example:
+                    examples:
                       - rel: "attributes"
                         href: "http://localhost:5101/datasets/d-d257f938-3854-11e8-a123-0242ac110009/attributes?domain=/home/test_user_1/file"
                       - rel': "data"
@@ -1199,23 +1246,29 @@ paths:
                   id:
                     description: UUID of this Dataset.
                     type: string
-                    example: "d-21ae0bbe-2dea-11e8-9391-0242ac110009"
+                    examples:
+                      - "d-21ae0bbe-2dea-11e8-9391-0242ac110009"
                   root:
                     description: UUID of root Group in Domain.
                     type: string
-                    example: "g-d313d498-2de4-11e8-9391-0242ac110009"
+                    examples:
+                      - "g-d313d498-2de4-11e8-9391-0242ac110009"
                   domain:
                     type: string
-                    example: "/home/test_user1/file"
+                    examples:
+                      - "/home/test_user1/file"
                   created:
                     type: number
-                    example: 1521734424.3
+                    examples:
+                      - 1521734424.3
                   lastModified:
                     type: number
-                    example: 1521734424.3
+                    examples:
+                      - 1521734424.3
                   attributeCount:
                     type: number
-                    example: 0
+                    examples:
+                      - 0
                   "type":
                     description: TODO
                     type: object
@@ -1253,9 +1306,9 @@ paths:
                               description: >
                                 Enum of pre-defined type, UUID of committed type,
                                 or type definition. (TODO: see `POST Dataset`?)
-                    example:
-                      base: H5T_STD_U32LE
-                      class: H5T_INTEGER
+                    examples:
+                      - base: H5T_STD_U32LE
+                        class: H5T_INTEGER
                   shape:
                     description: TODO
                     type: object
@@ -1295,16 +1348,16 @@ paths:
                           `maxdims` was included upon Dataset creation.
                         items:
                           type: number
-                    example:
-                      class: H5S_SIMPLE
-                      dims: [4, 4, 4]
-                      maxdims: [4, 4, 4]
+                    examples:
+                      - class: H5S_SIMPLE
+                        dims: [4, 4, 4]
+                        maxdims: [4, 4, 4]
                   layout:
                     description: TODO
                     type: object
-                    example:
-                      dims: [4, 4, 4]
-                      class: H5D_CHUNKED
+                    examples:
+                      - dims: [4, 4, 4]
+                        class: H5D_CHUNKED
                   creationProperties:
                     description: >
                       Dataset creation properties as provided upon creation.
@@ -1406,8 +1459,8 @@ paths:
                     type: array
                     items:
                       type: string # never relevant
-                example:
-                  hrefs: []
+                examples:
+                  - hrefs: []
         default:
           description: Operation unsuccessful.
 
@@ -1568,7 +1621,8 @@ paths:
                   type: array
                   items:
                     type: string
-                  example: [[4, 3, 1], [6, 1, 2], [12, 0, 0]]
+                  examples:
+                    - [[4, 3, 1], [6, 1, 2], [12, 0, 0]]
                 value:
                   description: >
                     JSON array containing values to write.
@@ -1577,7 +1631,8 @@ paths:
                   type: array
                   items:
                     type: string # TODO: not really...
-                  example: [323, 16, 44]
+                  examples:
+                    - [323, 16, 44]
                 value_base64:
                   description: >
                     Base64-encoded binary data.
@@ -1705,11 +1760,11 @@ paths:
       ##        step:
       ##          description: Positive, non-zero integer. Default `1`.
       ##          type: number
-      ##    example: # array of 'objects'
-      ##      - {}
-      ##      - {"start": 3, "stop": 19, "step": 4}
-      ##      - {"stop": 10, "step: 3}
-      ##      - {"start": 126}
+      ##    examples: # array of 'objects'
+      ##      - [{},
+      ##       {"start": 3, "stop": 19, "step": 4},
+      ##       {"stop": 10, "step: 3},
+      ##       {"start": 126}]
       ##    # would get [[0,1,..,n], [3,7,11,15], [0,3,6,9], [126,127,..,n]]
       ##  query:
       ##    description: >
@@ -1749,19 +1804,22 @@ paths:
                     type: array
                     items:
                       type: string # TODO: integer or array of integers WISHLIST: arrays
-                    example: [0, 1, 2, 3, 4, 5, 6, 7]
+                    examples:
+                      - [0, 1, 2, 3, 4, 5, 6, 7]
                   values:
                     type: array
                     items: {}
-                    example: # yaml syntax for easy-readable array of arrays
-                      - [1, 3, 5, 7]
-                      - [2, 6, 10, 14]
-                      - [3, 9, 15, 21]
-                      - [4, 12, 20, 28]
-                      - [5, 15, 25, 35]
-                      - [6, 18, 30, 42]
-                      - [7, 21, 35, 49]
-                      - [8, 24, 40, 56]
+                    examples:
+                      - [
+                          [1, 3, 5, 7],
+                          [2, 6, 10, 14],
+                          [3, 9, 15, 21],
+                          [4, 12, 20, 28],
+                          [5, 15, 25, 35],
+                          [6, 18, 30, 42],
+                          [7, 21, 35, 49],
+                          [8, 24, 40, 56],
+                        ]
         default:
           description: Operation unsuccessful.
 
@@ -1788,7 +1846,8 @@ paths:
                     type: array # TODO: verify array of arrays; esp. in single-coordinate case... [[5,3]], vs [5,3]
                     items:
                       type: number
-                  example: [[0, 0], [0, 1], [1, 0], [1, 1]]
+                  examples:
+                    - [[0, 0], [0, 1], [1, 0], [1, 1]]
       responses:
         "200":
           description: OK
@@ -1800,7 +1859,8 @@ paths:
                   value:
                     type: array
                     items: {}
-                    example: [0, 1, 1, 2]
+                    examples:
+                      - [0, 1, 1, 2]
         default:
           description: Operation unsuccessful.
 
@@ -1836,7 +1896,8 @@ paths:
                       type: string
                       description: >
                         Must be "H5T_COMPOUND"?
-                      example: H5T_COMPOUND
+                      examples:
+                        - H5T_COMPOUND
                     fields:
                       type: array
                       items:
@@ -1852,11 +1913,11 @@ paths:
 
                               TODO: pre-defined enum string vs type object?
                             type: string
-                      example:
-                        - name: temp
-                          type: "H5T_STD_I32LE"
-                        - name: pressure
-                          type: "H5T_IEEE_F32LE"
+                      examples:
+                        - [
+                            { name: temp, type: "H5T_STD_I32LE" },
+                            { name: pressure, type: "H5T_IEEE_F32LE" },
+                          ]
       responses:
         "201":
           description: CREATED
@@ -1954,7 +2015,8 @@ paths:
                         rel:
                           type: string
                           description: relation to this object
-                    example: []
+                    examples:
+                      - []
         default:
           description: Operation unsuccessful.
 
@@ -2041,7 +2103,8 @@ paths:
                         rel:
                           type: string
                           description: relation to this object
-                    example: []
+                    examples:
+                      - []
         default:
           description: Operation unsuccessful.
 
@@ -2107,7 +2170,8 @@ paths:
         #                    rel:
         #                      type: string
         #                      description: relation to this object
-        #                example: []
+        #                examples:
+        #4                - []
         default:
           description: Operation unsuccessful.
 
@@ -2176,7 +2240,8 @@ paths:
                         rel:
                           type: string
                           description: relation to this object
-                    example: []
+                    examples:
+                      - []
         default:
           description: Operation unsuccessful.
 
@@ -2214,7 +2279,8 @@ paths:
                         rel:
                           type: string
                           description: relation to this object
-                    example: []
+                    examples:
+                      - []
         default:
           description: Operation unsuccessful.
 
@@ -2257,7 +2323,8 @@ paths:
                         rel:
                           type: string
                           description: relation to this object
-                    example: []
+                    examples:
+                      - []
         default:
           description: Operation unsuccessful.
 
@@ -2323,7 +2390,8 @@ paths:
                         rel:
                           type: string
                           description: relation to this object
-                example: []
+                examples:
+                  - []
         default:
           description: Operation unsuccessful.
 
@@ -2362,7 +2430,8 @@ paths:
                         rel:
                           type: string
                           description: relation to this object
-                    example: []
+                    examples:
+                      - []
         default:
           description: Operation unsuccessful.
 
@@ -2406,7 +2475,8 @@ paths:
                         rel:
                           type: string
                           description: relation to this object
-                    example: []
+                    examples:
+                      - []
         default:
           description: Operation unsuccessful.
 
@@ -2444,7 +2514,8 @@ paths:
                         rel:
                           type: string
                           description: relation to this object
-                    example: []
+                    examples:
+                      - []
         default:
           description: Operation unsuccessful.
 
@@ -2483,7 +2554,8 @@ paths:
                         rel:
                           type: string
                           description: Relation to `href`.
-                    example: []
+                    examples:
+                      - []
         default:
           description: Operation unsuccessful.
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,4 +1,4 @@
-openapi: '3.0.0'
+openapi: "3.0.0"
 
 info:
   title: HDF Scalable Data Service REST API
@@ -7,17 +7,15 @@ info:
     name: The HDF Group
     url: https://www.hdfgroup.org
     email: info@hdfgroup.org
-# termsOfService: TODO url
-# license
-#   name: TODO
-#   url: TODO
-  version: '2.0'
-
+  # termsOfService: TODO url
+  # license
+  #   name: TODO
+  #   url: TODO
+  version: "2.0"
 
 externalDocs:
   description: HSDS REST API documentation
-  url: 'http://h5serv.readthedocs.io/en/latest/index.html'
-
+  url: "http://h5serv.readthedocs.io/en/latest/index.html"
 
 tags:
   - name: Domain
@@ -35,11 +33,9 @@ tags:
   - name: ACLS
     description: Operations involving Attributes.
 
-
 servers:
   - url: http://hsdshdflab.hdfgroup.org
     description: HSDS default server
-
 
 components:
   schemas:
@@ -67,7 +63,7 @@ components:
       description: Access Control Lists for users.
       properties:
         forWhom:
-          $ref: '#/components/schemas/ACL'
+          $ref: "#/components/schemas/ACL"
       example:
         test_user1:
           create: true
@@ -85,25 +81,15 @@ components:
           readACL: false
 
   parameters:
-    accept_json:
-      name: Accept
-      in: header
-      required: true
-      description: Accept header
-      schema:
-        type: string
-        enum:
-          - 'application/json'
-        default: 'application/json'
     authorization:
       in: header
       name: Authorization
       schema:
         type: string
         description: >
-            Credentials for the request.
+          Credentials for the request.
 
-            'Basic' authorization, `"Basic " + base64(<username>:<password>)`
+          'Basic' authorization, `"Basic " + base64(<username>:<password>)`
     linkname:
       in: path
       name: linkname
@@ -111,23 +97,15 @@ components:
       schema:
         type: string
         description: >
-            URL-encoded name of the Link.
-            Label/name/title of the Link, e.g., `dset1` or `group3`.
-            `linkname` cannot contain slashes.
+          URL-encoded name of the Link.
+          Label/name/title of the Link, e.g., `dset1` or `group3`.
+          `linkname` cannot contain slashes.
     query_domain:
       in: query
       name: domain
       schema:
         type: string
         description: Domain on service to access, e.g., `/home/user/someproject/somefile`.
-    content_json_only:
-      in: header
-      name: Content-Type
-      schema:
-        type: string
-        enum:
-          - application/json
-        default: application/json
     path_group_uuid:
       in: path
       name: id
@@ -155,7 +133,6 @@ components:
       type: http
       scheme: basic
 
-
 paths:
   /:
     put:
@@ -163,40 +140,39 @@ paths:
         - Domain
       summary: Create a new Domain on the service.
       description: >
-          Domains represent dataspaces analogous to hdf5 files.
+        Domains represent dataspaces analogous to hdf5 files.
 
-          Folders are 'placeholder' domains which lack a root Group. Their
-          main use is to manage top-level directories (outside of user space)
-          and to fill out a user's directory paths if required.
-          E.g., `/home/user/project/missingdir/data.h5`
+        Folders are 'placeholder' domains which lack a root Group. Their
+        main use is to manage top-level directories (outside of user space)
+        and to fill out a user's directory paths if required.
+        E.g., `/home/user/project/missingdir/data.h5`
 
-          Note: Initially, the only object in a Domain is the root group. Use
-          other `put` and `post` operations to create new objects in the
-          domain.
+        Note: Initially, the only object in a Domain is the root group. Use
+        other `put` and `post` operations to create new objects in the
+        domain.
 
-          Note: Domains (and Folders) may only be created as direct children
-          of existing Domains. e.g., `/home/user/project/missingdir` _must_
-          exist prior to the creation of Domain
-          `/home/user/project/missingdir/data.h5`.
+        Note: Domains (and Folders) may only be created as direct children
+        of existing Domains. e.g., `/home/user/project/missingdir` _must_
+        exist prior to the creation of Domain
+        `/home/user/project/missingdir/data.h5`.
 
-          Note: The operation will fail if the domain already exists
-          (Error 409).
+        Note: The operation will fail if the domain already exists
+        (Error 409).
       requestBody:
         content:
           application/json:
             schema:
               type: object
       parameters:
-        - $ref: '#/components/parameters/query_domain'
+        - $ref: "#/components/parameters/query_domain"
         - name: folder
           in: query
           schema:
             type: number
           description: If present and `1`, creates a Folder instead of a Domain.
-        - $ref: '#/components/parameters/accept_json'
-        - $ref: '#/components/parameters/authorization'
+        - $ref: "#/components/parameters/authorization"
       responses:
-        '201':
+        "201":
           description: Created.
           headers:
             Content-Length:
@@ -219,7 +195,7 @@ paths:
                 type: object
                 properties:
                   acls:
-                    $ref: '#/components/schemas/ACLS'
+                    $ref: "#/components/schemas/ACLS"
                   created:
                     description: When domain was created.
                     type: number
@@ -231,11 +207,11 @@ paths:
                   owner:
                     description: Name of owner.
                     type: string
-                    example: 'test_user1'
+                    example: "test_user1"
                   root:
                     description: ID of root group.
                     type: string
-                    example: 'g-82da0346-2b9e-11e8-9391-0242ac110009'
+                    example: "g-82da0346-2b9e-11e8-9391-0242ac110009"
         default:
           description: Operation unsuccessful.
 
@@ -244,17 +220,16 @@ paths:
         - Domain
       summary: Get information about the requested domain.
       description: >
-          If the domain is of class 'folder', `root` is absent from returned
-          JSON object.
+        If the domain is of class 'folder', `root` is absent from returned
+        JSON object.
 
-          If no domain query parameter is provided, returns:
-          `{"domains": [], "href": []}`
+        If no domain query parameter is provided, returns:
+        `{"domains": [], "href": []}`
       parameters:
-        - $ref: '#/components/parameters/query_domain'
-        - $ref: '#/components/parameters/accept_json'
-        - $ref: '#/components/parameters/authorization'
+        - $ref: "#/components/parameters/query_domain"
+        - $ref: "#/components/parameters/authorization"
       responses:
-        '200':
+        "200":
           description: Operation successful.
           headers:
             content-length:
@@ -278,17 +253,17 @@ paths:
                 properties:
                   root:
                     description: >
-                        UUID of root Group.
-                        If Domain is of class 'folder', this entry is not present.
+                      UUID of root Group.
+                      If Domain is of class 'folder', this entry is not present.
                     type: string
-                    example: 'g-82da0346-2b9e-11e8-9391-0242ac110009'
+                    example: "g-82da0346-2b9e-11e8-9391-0242ac110009"
                   owner:
                     type: string
-                    example: 'test_user1'
+                    example: "test_user1"
                   class:
                     description: >
-                        Category of Domain.
-                        If 'folder' no root group is included in response.
+                      Category of Domain.
+                      If 'folder' no root group is included in response.
                     type: string
                     enum:
                       - domain
@@ -302,15 +277,15 @@ paths:
                     example: 1521476710.039304
                   hrefs:
                     description: >
-                        Array of url references and their relation to this Domain.
-                        Should include entries for:
-                        `acls`,
-                        `database` (if not class is not `folder`),
-                        `groupbase` (if not class is not `folder`),
-                        `parent`,
-                        `root` (if not class is not `folder`),
-                        `self`,
-                        `typebase` (if not class is not `folder`).
+                      Array of url references and their relation to this Domain.
+                      Should include entries for:
+                      `acls`,
+                      `database` (if not class is not `folder`),
+                      `groupbase` (if not class is not `folder`),
+                      `parent`,
+                      `root` (if not class is not `folder`),
+                      `self`,
+                      `typebase` (if not class is not `folder`).
                     type: array
                     items:
                       type: object
@@ -323,19 +298,19 @@ paths:
                           type: string
                     example:
                       - rel: acls
-                        href: 'http://myfile.test_user1.home/acls'
+                        href: "http://myfile.test_user1.home/acls"
                       - rel: database
-                        href: 'http://myfile.test_user1.home/datasets'
+                        href: "http://myfile.test_user1.home/datasets"
                       - rel: groupbase
-                        href: 'http://myfile.test_user1.home/groups'
+                        href: "http://myfile.test_user1.home/groups"
                       - rel: parent
-                        href: 'http://myfile.test_user1.home/?domain=/home/test_user1'
+                        href: "http://myfile.test_user1.home/?domain=/home/test_user1"
                       - rel: root
-                        href: 'http://myfile.test_user1.home/groups/g-17d88042-2b92-11e8-9391-0242ac110009'
+                        href: "http://myfile.test_user1.home/groups/g-17d88042-2b92-11e8-9391-0242ac110009"
                       - rel: self
-                        href: 'http://myfile.test_user1.home/'
+                        href: "http://myfile.test_user1.home/"
                       - rel: typebase
-                        href: 'http://myfile.test_user1.home/datatypes/'
+                        href: "http://myfile.test_user1.home/datatypes/"
         default:
           description: Operation unsuccessful.
 
@@ -344,19 +319,18 @@ paths:
         - Domain
       summary: Delete the specified Domain or Folder.
       description: >
-          Delete the domain and all associated groups, datasets, attributes,
-          etc.
+        Delete the domain and all associated groups, datasets, attributes,
+        etc.
 
-          Note: if there are Domains which are children of this Domain
-          (e.g., deleting `somedir` from `/home/user/project/somedir/data.h5`),
-          those children directories will _not_ be deleted.
-          (TODO: abandoned children is incorrect behavior?)
+        Note: if there are Domains which are children of this Domain
+        (e.g., deleting `somedir` from `/home/user/project/somedir/data.h5`),
+        those children directories will _not_ be deleted.
+        (TODO: abandoned children is incorrect behavior?)
       parameters:
-        - $ref: '#/components/parameters/query_domain'
-        - $ref: '#/components/parameters/accept_json'
-        - $ref: '#/components/parameters/authorization'
+        - $ref: "#/components/parameters/query_domain"
+        - $ref: "#/components/parameters/authorization"
       responses:
-        '200':
+        "200":
           description: Operation successful.
           headers:
             content-length:
@@ -382,36 +356,34 @@ paths:
                   domain:
                     type: string
                     description: domain path
-                    example: '/home/test_user/some_path/some_file'
+                    example: "/home/test_user/some_path/some_file"
         default:
           description: Operation unsuccessful.
 
   # end '/'
 
   /groups:
-
     post:
       tags:
         - Domain
         - Group
       summary: Create a new Group.
       description: >
-          Create a new Group in the given Domain.
+        Create a new Group in the given Domain.
 
-          By default, the new Group it not attached to any other object in the
-          Domain; it is left to the user or application to appropriately attach
-          the new Group, i.e., Link to.
+        By default, the new Group it not attached to any other object in the
+        Domain; it is left to the user or application to appropriately attach
+        the new Group, i.e., Link to.
 
-          A link description may be supplied in the request body as
-          structured JSON, which will immediately link the new Group. If
-          supplying link info, the header `Content-Type: application/json`
-          should also be supplied as a matter of course. Note that this
-          link will be a hard link -- it refers directly to the object.
+        A link description may be supplied in the request body as
+        structured JSON, which will immediately link the new Group. If
+        supplying link info, the header `Content-Type: application/json`
+        should also be supplied as a matter of course. Note that this
+        link will be a hard link -- it refers directly to the object.
       parameters:
-        - $ref: '#/components/parameters/query_domain'
-        - $ref: '#/components/parameters/accept_json'
-        - $ref: '#/components/parameters/authorization'
-        - $ref: '#/components/parameters/content_json_only'
+        - $ref: "#/components/parameters/query_domain"
+        - $ref: "#/components/parameters/authorization"
+
       requestBody:
         content:
           application/json:
@@ -420,30 +392,30 @@ paths:
               properties:
                 link:
                   description: >
-                      Optional JSON object to immediately create a hard Link to
-                      the newly-created object. If present, both `id` and `name`
-                      must be supplied and `id` must be the UUID of an existing
-                      Group -- UUID of any non-Group object will result in an
-                      error.
+                    Optional JSON object to immediately create a hard Link to
+                    the newly-created object. If present, both `id` and `name`
+                    must be supplied and `id` must be the UUID of an existing
+                    Group -- UUID of any non-Group object will result in an
+                    error.
 
-                      Note that the id reference is _reverse_ the usual for Link
-                      creation: the `id` value refers to the targeting object,
-                      not the target object of the link.
+                    Note that the id reference is _reverse_ the usual for Link
+                    creation: the `id` value refers to the targeting object,
+                    not the target object of the link.
                   type: object
                   required:
                     - id
                     - name
                   properties:
                     id:
-                      description: 'UUID of Group to link from.'
+                      description: "UUID of Group to link from."
                       type: string
-                      example: 'g-a613ed48-2c86-11e8-9391-0242ac110009'
+                      example: "g-a613ed48-2c86-11e8-9391-0242ac110009"
                     name:
                       description: Title of Link.
                       type: string
-                      example: 'g2'
+                      example: "g2"
       responses:
-        '201':
+        "201":
           description: New Group created.
           headers:
             content-length:
@@ -454,12 +426,6 @@ paths:
               description: Hash-code status of resource.
               schema:
                 type: string
-            Content-Type:
-              description: MIME type of response -- always 'application/json'
-              schema:
-                type: string
-                enum:
-                  - application/json
           content:
             application/json:
               schema:
@@ -468,11 +434,11 @@ paths:
                   id:
                     description: UUID of new Group.
                     type: string
-                    example: 'g-a613ed48-2c86-11e8-9391-0242ac110009'
+                    example: "g-a613ed48-2c86-11e8-9391-0242ac110009"
                   root:
                     description: UUID of root Group in Domain.
                     type: string
-                    example: 'g-37aa76f6-2c86-11e8-9391-0242ac110009'
+                    example: "g-37aa76f6-2c86-11e8-9391-0242ac110009"
                   lastModified:
                     type: number
                     example: 1521581745.9365487
@@ -494,19 +460,18 @@ paths:
         - Group
       summary: Get UUIDs for all non-root Groups in Domain.
       description: >
-          Listed Group(s) must be reachable via hard Link from root Group,
-          either directly or indirectly. If Groups exist which are unlinked or
-          not reachable by tree originating at root, they will not be included
-          in the list.
+        Listed Group(s) must be reachable via hard Link from root Group,
+        either directly or indirectly. If Groups exist which are unlinked or
+        not reachable by tree originating at root, they will not be included
+        in the list.
 
-          If there is any hard Link in the tree to a Group which has been
-          deleted, the request will fail with error 410 (GONE).
+        If there is any hard Link in the tree to a Group which has been
+        deleted, the request will fail with error 410 (GONE).
       parameters:
-        - $ref: '#/components/parameters/query_domain'
-        - $ref: '#/components/parameters/accept_json'
-        - $ref: '#/components/parameters/authorization'
+        - $ref: "#/components/parameters/query_domain"
+        - $ref: "#/components/parameters/authorization"
       responses:
-        '200':
+        "200":
           description: OK
           headers:
             content-length:
@@ -532,20 +497,20 @@ paths:
                       description: UUID of each Group.
                       type: string
                     example:
-                    - 'g-a613ed48-2c86-11e8-9391-0242ac110009'
-                    - 'g-37aa76f6-2c86-11e8-9391-0242ac110009'
+                      - "g-a613ed48-2c86-11e8-9391-0242ac110009"
+                      - "g-37aa76f6-2c86-11e8-9391-0242ac110009"
                   hrefs:
                     type: array
                     items:
                       description: >
-                          References to other objects.
+                        References to other objects.
 
-                          Must contain references for only:
-                          `attributes`,
-                          `home`,
-                          `links`,
-                          `root`,
-                          `self`.
+                        Must contain references for only:
+                        `attributes`,
+                        `home`,
+                        `links`,
+                        `root`,
+                        `self`.
                       type: object
                       properties:
                         href:
@@ -555,32 +520,30 @@ paths:
                           description: Relation to this object.
                           type: string
                     example:
-                      - rel: 'attributes'
-                        href: 'http://localhost:5101/groups/g-ee2f6a2c-3847-11e8-a123-0242ac110009/attributes?domain=/home/test_user1/file'
-                      - rel: 'home'
-                        href: 'http://localhost:5101/?domain=/home/test_user1/file'
-                      - rel: 'links'
-                        href: 'http://localhost:5101/groups/g-ee2f6a2c-3847-11e8-a123-0242ac110009/links?domain=/home/test_user1/file'
-                      - rel: 'root'
-                        href: 'http://localhost:5101/groups/g-ed14d712-3847-11e8-a123-0242ac110009?domain=/home/test_user1/file'
-                      - rel: 'self'
-                        href: 'http://localhost:5101/groups/g-ee2f6a2c-3847-11e8-a123-0242ac110009?domain=/home/test_user1/file'
+                      - rel: "attributes"
+                        href: "http://localhost:5101/groups/g-ee2f6a2c-3847-11e8-a123-0242ac110009/attributes?domain=/home/test_user1/file"
+                      - rel: "home"
+                        href: "http://localhost:5101/?domain=/home/test_user1/file"
+                      - rel: "links"
+                        href: "http://localhost:5101/groups/g-ee2f6a2c-3847-11e8-a123-0242ac110009/links?domain=/home/test_user1/file"
+                      - rel: "root"
+                        href: "http://localhost:5101/groups/g-ed14d712-3847-11e8-a123-0242ac110009?domain=/home/test_user1/file"
+                      - rel: "self"
+                        href: "http://localhost:5101/groups/g-ee2f6a2c-3847-11e8-a123-0242ac110009?domain=/home/test_user1/file"
         default:
           description: Operation unsuccessful.
 
   # end '/groups/'
 
   /groups/{id}:
-
     get:
       tags:
         - Group
       summary: Get information about a Group.
       parameters:
-        - $ref: '#/components/parameters/path_group_uuid'
-        - $ref: '#/components/parameters/query_domain'
-        - $ref: '#/components/parameters/accept_json'
-        - $ref: '#/components/parameters/authorization'
+        - $ref: "#/components/parameters/path_group_uuid"
+        - $ref: "#/components/parameters/query_domain"
+        - $ref: "#/components/parameters/authorization"
         - name: getalias
           in: query
           schema:
@@ -589,13 +552,13 @@ paths:
               - 0
               - 1
             description: >
-                Optional body content, gets the alias (path name(s) from root) of
-                the group as part of the response. Only includes paths as reached
-                via _hard_ Links.
+              Optional body content, gets the alias (path name(s) from root) of
+              the group as part of the response. Only includes paths as reached
+              via _hard_ Links.
 
-                If present, must be either `0` (no alias list) or `1` (alias list).
+              If present, must be either `0` (no alias list) or `1` (alias list).
       responses:
-        '200':
+        "200":
           description: OK
           headers:
             content-length:
@@ -625,10 +588,10 @@ paths:
                     example: g-37aa76f6-2c86-11e8-9391-0242ac110009
                   alias:
                     description: >
-                        List of aliases for the Group, as reached by _hard_ Links.
-                        If Group is unlinked, its alias list will be empty (`[]`).
+                      List of aliases for the Group, as reached by _hard_ Links.
+                      If Group is unlinked, its alias list will be empty (`[]`).
 
-                        Only present if `alias=1` is present as query parameter.
+                      Only present if `alias=1` is present as query parameter.
                     type: array
                     items:
                       type: string
@@ -641,7 +604,7 @@ paths:
                     example: 1521644498.984212
                   domain:
                     type: string
-                    example: '/home/test_user1/file'
+                    example: "/home/test_user1/file"
                   attributeCount:
                     type: number
                     example: 4
@@ -653,35 +616,35 @@ paths:
                     type: array
                     items:
                       description: >
-                          References to other objects.
+                        References to other objects.
 
-                          Must contain references for only:
-                          `attributes`,
-                          `home`,
-                          `links`,
-                          `root`,
-                          `self`.
+                        Must contain references for only:
+                        `attributes`,
+                        `home`,
+                        `links`,
+                        `root`,
+                        `self`.
                       type: object
                       properties:
                         rel:
                           description: Relation to this object.
                           type: string
-                          example: 'self'
+                          example: "self"
                         href:
                           description: URL to reference.
                           type: string
-                          example: 'http://myfile.test_user1.home/'
+                          example: "http://myfile.test_user1.home/"
                     example:
-                      - rel: 'attributes'
-                        href: 'http://localhost:5101/groups/g-37aa76f6-2c86-11e8-9391-0242ac110009/attributes?domain=/home/test_user1/file'
-                      - rel: 'home'
-                        href: 'http://localhost:5101/?domain=/home/test_user1/file'
-                      - rel: 'links'
-                        href: 'http://localhost:5101/groups/g-37aa76f6-2c86-11e8-9391-0242ac110009/links?domain=/home/test_user1/file'
-                      - rel: 'root'
-                        href: 'http://localhost:5101/groups/g-37aa76f6-2c86-11e8-9391-0242ac110009?domain=/home/test_user1/file'
-                      - rel: 'self'
-                        href: 'http://localhost:5101/groups/g-37aa76f6-2c86-11e8-9391-0242ac110009?domain=/home/test_user1/file'
+                      - rel: "attributes"
+                        href: "http://localhost:5101/groups/g-37aa76f6-2c86-11e8-9391-0242ac110009/attributes?domain=/home/test_user1/file"
+                      - rel: "home"
+                        href: "http://localhost:5101/?domain=/home/test_user1/file"
+                      - rel: "links"
+                        href: "http://localhost:5101/groups/g-37aa76f6-2c86-11e8-9391-0242ac110009/links?domain=/home/test_user1/file"
+                      - rel: "root"
+                        href: "http://localhost:5101/groups/g-37aa76f6-2c86-11e8-9391-0242ac110009?domain=/home/test_user1/file"
+                      - rel: "self"
+                        href: "http://localhost:5101/groups/g-37aa76f6-2c86-11e8-9391-0242ac110009?domain=/home/test_user1/file"
         default:
           description: Operation unsuccessful.
 
@@ -702,12 +665,11 @@ paths:
         `GET /groups` requests to fail with error 410 (GONE) until all Links to
         the deleted Group are also deleted.
       parameters:
-        - $ref: '#/components/parameters/path_group_uuid'
-        - $ref: '#/components/parameters/query_domain'
-        - $ref: '#/components/parameters/accept_json'
-        - $ref: '#/components/parameters/authorization'
+        - $ref: "#/components/parameters/path_group_uuid"
+        - $ref: "#/components/parameters/query_domain"
+        - $ref: "#/components/parameters/authorization"
       responses:
-        '200':
+        "200":
           description: Group removed.
           content:
             application/json:
@@ -719,43 +681,41 @@ paths:
   # end '/groups/{id}'
 
   /groups/{id}/links:
-
     get:
       tags:
         - Link
       summary: List all Links in a Group.
       description: >
-          Items in the "list" array are sorted alphanumerically by title.
+        Items in the "list" array are sorted alphanumerically by title.
       parameters:
-        - $ref: '#/components/parameters/path_group_uuid'
-        - $ref: '#/components/parameters/query_domain'
+        - $ref: "#/components/parameters/path_group_uuid"
+        - $ref: "#/components/parameters/query_domain"
         - name: Limit
           in: query
           schema:
             type: number
           description: >
-              Cap the number of Links returned in list.
+            Cap the number of Links returned in list.
 
-              Must be an integer `N >= 0`.
+            Must be an integer `N >= 0`.
 
-              May be greater than or equal to the number of Links; has no
-              effect in that case.
+            May be greater than or equal to the number of Links; has no
+            effect in that case.
 
-              May be used in conjunction with query parameter `Marker`.
+            May be used in conjunction with query parameter `Marker`.
         - name: Marker
           in: query
           schema:
             type: string
           description: >
-              Title of a Link; the first Link name to list.
+            Title of a Link; the first Link name to list.
 
-              If no Link exists with that title, causes an error.
+            If no Link exists with that title, causes an error.
 
-              May be used with query parameter `Limit`.
-        - $ref: '#/components/parameters/accept_json'
-        - $ref: '#/components/parameters/authorization'
+            May be used with query parameter `Limit`.
+        - $ref: "#/components/parameters/authorization"
       responses:
-        '200':
+        "200":
           description: OK
           content:
             application/json:
@@ -770,53 +730,53 @@ paths:
                         id:
                           description: UUID of Link target.
                           type: string
-                          example: 'g-a613ed48-2c86-11e8-9391-0242ac110009'
+                          example: "g-a613ed48-2c86-11e8-9391-0242ac110009"
                         created:
                           type: number
                           example: 1521644498.984212
                         class:
                           description: >
-                              Indicate whether this Link is hard, soft, or
-                              external.
+                            Indicate whether this Link is hard, soft, or
+                            external.
                           type: string
                           enum:
-                            - 'H5L_TYPE_HARD'
-                            - 'H5L_TYPE_SOFT'
-                            - 'H5L_TYPE_EXTERNAL'
-                          example: 'H5L_TYPE_HARD'
+                            - "H5L_TYPE_HARD"
+                            - "H5L_TYPE_SOFT"
+                            - "H5L_TYPE_EXTERNAL"
+                          example: "H5L_TYPE_HARD"
                         title:
                           description: >
-                              Name/label/title of the Link, as provided upon
-                              creation.
+                            Name/label/title of the Link, as provided upon
+                            creation.
                           type: string
-                          example: 'g1'
+                          example: "g1"
                         target:
                           description: URL of Link target.
                           type: string
-                          example: 'http://localhost:5101/groups/g-a613ed48-2c86-11e8-9391-0242ac110009?domain=/home/test_user1/file'
+                          example: "http://localhost:5101/groups/g-a613ed48-2c86-11e8-9391-0242ac110009?domain=/home/test_user1/file"
                         href:
                           description: URL to origin of Link.
                           type: string
-                          example: 'http://localhost:5101/groups/g-37aa76f6-2c86-11e8-9391-0242ac110009/links/g1?domain=/home/test_user1/file'
+                          example: "http://localhost:5101/groups/g-37aa76f6-2c86-11e8-9391-0242ac110009/links/g1?domain=/home/test_user1/file"
                         collection:
                           description: >
-                              What kind of object is the target. (TODO)
+                            What kind of object is the target. (TODO)
                           type: string
                           enum:
-                            - 'groups'
-                            - 'datasets'
+                            - "groups"
+                            - "datasets"
                           #  - 'datatypes' TODO
                           #  - 'attributes' TODO
-                          example: 'groups'
+                          example: "groups"
                   hrefs:
                     type: array
                     description: >
-                        List of references to other entities.
+                      List of references to other entities.
 
-                        Should contain references for:
-                        `home`,
-                        `owner`,
-                        `self`.
+                      Should contain references for:
+                      `home`,
+                      `owner`,
+                      `self`.
                     items:
                       type: object
                       properties:
@@ -839,38 +799,36 @@ paths:
   # end '/groups/{id}/links':
 
   /groups/{id}/links/{linkname}:
-
     put:
       tags:
         - Link
       summary: Create a new Link in a Group.
       description: >
-          Link will be 'hard', 'soft', or 'external' depending on request
-          elements.
+        Link will be 'hard', 'soft', or 'external' depending on request
+        elements.
 
-          If `id` is provided, it will override other properties and attempt to
-          create a hard Link to the object with that UUID.
+        If `id` is provided, it will override other properties and attempt to
+        create a hard Link to the object with that UUID.
 
-          If `h5path` is provided, will create a symbolic link to object (if
-          any) at the given path -- either a soft Link within this domain if no
-          domain is specified, or an external Link.
+        If `h5path` is provided, will create a symbolic link to object (if
+        any) at the given path -- either a soft Link within this domain if no
+        domain is specified, or an external Link.
 
-          If `h5domain` is provided, will create an external Link, pointing to
-          the object (if any) at `h5path` in domain `h5domain`.
+        If `h5domain` is provided, will create an external Link, pointing to
+        the object (if any) at `h5path` in domain `h5domain`.
       parameters:
-        - $ref: '#/components/parameters/path_group_uuid'
-        - $ref: '#/components/parameters/linkname'
-        - $ref: '#/components/parameters/query_domain'
-        - $ref: '#/components/parameters/accept_json'
-        - $ref: '#/components/parameters/authorization'
-        - $ref: '#/components/parameters/content_json_only'
+        - $ref: "#/components/parameters/path_group_uuid"
+        - $ref: "#/components/parameters/linkname"
+        - $ref: "#/components/parameters/query_domain"
+        - $ref: "#/components/parameters/authorization"
+
       requestBody:
         description: >
-            JSON object describing the Link to create.
+          JSON object describing the Link to create.
 
-            Requires at least one of `id` and `h5path`; if both supplied,
-            `id` takes priority. `h5domain` applies only if `h5path` is
-            present, providing the Domain for an external Link.
+          Requires at least one of `id` and `h5path`; if both supplied,
+          `id` takes priority. `h5domain` applies only if `h5path` is
+          present, providing the Domain for an external Link.
         required: true
         content:
           application/json:
@@ -887,7 +845,7 @@ paths:
 
                     Overrides other fields.
                   type: string
-                  example: 'g-37aa76f6-2c86-11e8-9391-0242ac110009'
+                  example: "g-37aa76f6-2c86-11e8-9391-0242ac110009"
                 h5path:
                   description: >
                     Path to an object relative to a Domain's root.
@@ -900,18 +858,18 @@ paths:
 
                     If used, will create a soft or external Link.
                   type: string
-                  example: '/dset1'
+                  example: "/dset1"
                 h5domain:
                   description: >
-                      URL of external domain.
+                    URL of external domain.
 
-                      Results in an external Link.
+                    Results in an external Link.
 
-                      Requires `h5path` be present.
+                    Requires `h5path` be present.
                   type: string
-                  example: 'external_target.test.hdfgroup.org'
+                  example: "external_target.test.hdfgroup.org"
       responses:
-        '201':
+        "201":
           description: New Link created.
           content:
             application/json:
@@ -929,14 +887,13 @@ paths:
       summary: Get Link info.
       description: Get information about a given Link.
       parameters:
-        - $ref: '#/components/parameters/path_group_uuid'
-        - $ref: '#/components/parameters/linkname'
-        - $ref: '#/components/parameters/query_domain'
-        - $ref: '#/components/parameters/accept_json'
-        - $ref: '#/components/parameters/authorization'
-        - $ref: '#/components/parameters/content_json_only'
+        - $ref: "#/components/parameters/path_group_uuid"
+        - $ref: "#/components/parameters/linkname"
+        - $ref: "#/components/parameters/query_domain"
+        - $ref: "#/components/parameters/authorization"
+
       responses:
-        '200':
+        "200":
           description: OK
           content:
             application/json:
@@ -952,26 +909,26 @@ paths:
                     properties:
                       id:
                         type: string
-                        example: 'g-a613ed48-2c86-11e8-9391-0242ac110009'
+                        example: "g-a613ed48-2c86-11e8-9391-0242ac110009"
                       title:
                         type: string
-                        example: 'g1'
+                        example: "g1"
                       collection:
                         type: string
-                        example: 'group'
+                        example: "group"
                       class:
                         type: string
-                        example: 'H5L_TYPE_HARD'
+                        example: "H5L_TYPE_HARD"
                   hrefs:
                     type: array
                     description: >
-                        List of references to other entities.
+                      List of references to other entities.
 
-                        Should contain references for:
-                        `home`,
-                        `owner`,
-                        `self`,
-                        `target`,
+                      Should contain references for:
+                      `home`,
+                      `owner`,
+                      `self`,
+                      `target`,
                     items:
                       type: object
                       properties:
@@ -982,14 +939,14 @@ paths:
                           description: Relation to this object.
                           type: string
                     example:
-                      - rel: 'home'
-                        href: 'http://localhost:5101/?domain=/home/test_user1/file'
-                      - rel: 'owner'
-                        href: 'http://localhost:5101/groups/g-8822ef7a-384b-11e8-a123-0242ac110009?domain=/home/test_user1/file'
-                      - rel: 'self'
-                        href: 'http://localhost:5101/groups/g-8822ef7a-384b-11e8-a123-0242ac110009/links/g1?domain=/home/test_user1/file'
-                      - rel: 'target'
-                        href: 'http://localhost:5101/groups/g-a613ed48-2c86-11e8-9391-0242ac110009?domain=/home/test_user1/file'
+                      - rel: "home"
+                        href: "http://localhost:5101/?domain=/home/test_user1/file"
+                      - rel: "owner"
+                        href: "http://localhost:5101/groups/g-8822ef7a-384b-11e8-a123-0242ac110009?domain=/home/test_user1/file"
+                      - rel: "self"
+                        href: "http://localhost:5101/groups/g-8822ef7a-384b-11e8-a123-0242ac110009/links/g1?domain=/home/test_user1/file"
+                      - rel: "target"
+                        href: "http://localhost:5101/groups/g-a613ed48-2c86-11e8-9391-0242ac110009?domain=/home/test_user1/file"
         default:
           description: Operation unsuccessful.
 
@@ -999,14 +956,13 @@ paths:
       summary: Delete Link.
       description: Will _not_ delete the target object.
       parameters:
-        - $ref: '#/components/parameters/path_group_uuid'
-        - $ref: '#/components/parameters/linkname'
-        - $ref: '#/components/parameters/query_domain'
-        - $ref: '#/components/parameters/accept_json'
-        - $ref: '#/components/parameters/authorization'
-        - $ref: '#/components/parameters/content_json_only'
+        - $ref: "#/components/parameters/path_group_uuid"
+        - $ref: "#/components/parameters/linkname"
+        - $ref: "#/components/parameters/query_domain"
+        - $ref: "#/components/parameters/authorization"
+
       responses:
-        '200':
+        "200":
           description: Link deleted.
           content:
             application/json:
@@ -1021,89 +977,87 @@ paths:
   # end '/groups/{id}/links/{linkname}'
 
   /datasets:
-
     post:
       tags:
         - Domain
         - Dataset
       summary: Create a Dataset.
       description: >
-          Create a new Dataset object in the Domain.
+        Create a new Dataset object in the Domain.
 
-          New object is not linked to or by any other object upon creation;
-          will not appear in `datasets` listing until linked to tree
-          originating at the Domain's root Group.
+        New object is not linked to or by any other object upon creation;
+        will not appear in `datasets` listing until linked to tree
+        originating at the Domain's root Group.
       parameters:
-        - $ref: '#/components/parameters/query_domain'
-        - $ref: '#/components/parameters/accept_json'
-        - $ref: '#/components/parameters/authorization'
-        - $ref: '#/components/parameters/content_json_only'
+        - $ref: "#/components/parameters/query_domain"
+        - $ref: "#/components/parameters/authorization"
+
       requestBody:
         description: >
-            JSON object describing the Dataset's properties.
+          JSON object describing the Dataset's properties.
         required: true
         content:
           application/json:
             schema:
               type: object
               properties:
-                'type':
+                "type":
                   description: >
-                      Predefined data Type, UUID of a commtted type, or JSON
-                      object description of a Type.
+                    Predefined data Type, UUID of a commtted type, or JSON
+                    object description of a Type.
 
-                      Must be present.
+                    Must be present.
 
-                      Predefined types are:
-                      `H5T_STD_U8BE`, (integer types of various sizes and
-                      `H5T_STD_U8LE`,  endainness)
-                      `H5T_STD_I8BE`,
-                      `H5T_STD_I8LE`,
-                      `H5T_STD_U16BE`,
-                      `H5T_STD_U16LE`,
-                      `H5T_STD_I16BE`,
-                      `H5T_STD_I16LE`,
-                      `H5T_STD_U32BE`,
-                      `H5T_STD_U32LE`,
-                      `H5T_STD_I32BE`,
-                      `H5T_STD_I32LE`,
-                      `H5T_STD_U64BE`,
-                      `H5T_STD_U64LE`,
-                      `H5T_STD_I64BE`,
-                      `H5T_STD_I64LE`,
-                      `H5T_IEEE_F32BE`, (floating-point types)
-                      `H5T_IEEE_F32LE`,
-                      `H5T_IEEE_F64BE`,
-                      `H5T_IEEE_F64LE`
+                    Predefined types are:
+                    `H5T_STD_U8BE`, (integer types of various sizes and
+                    `H5T_STD_U8LE`,  endainness)
+                    `H5T_STD_I8BE`,
+                    `H5T_STD_I8LE`,
+                    `H5T_STD_U16BE`,
+                    `H5T_STD_U16LE`,
+                    `H5T_STD_I16BE`,
+                    `H5T_STD_I16LE`,
+                    `H5T_STD_U32BE`,
+                    `H5T_STD_U32LE`,
+                    `H5T_STD_I32BE`,
+                    `H5T_STD_I32LE`,
+                    `H5T_STD_U64BE`,
+                    `H5T_STD_U64LE`,
+                    `H5T_STD_I64BE`,
+                    `H5T_STD_I64LE`,
+                    `H5T_IEEE_F32BE`, (floating-point types)
+                    `H5T_IEEE_F32LE`,
+                    `H5T_IEEE_F64BE`,
+                    `H5T_IEEE_F64LE`
 
-                      TODO: Type description objects.
-                      For now, see:
-                      http://h5serv.readthedocs.io/en/latest/Types/index.html
+                    TODO: Type description objects.
+                    For now, see:
+                    http://h5serv.readthedocs.io/en/latest/Types/index.html
                   type: string # TODO: ambiguous string or object
-                  example: 'H5T_STD_U32LE'
+                  example: "H5T_STD_U32LE"
                 shape:
                   description: >
-                      Either an integer array giving the initial dimensions of
-                      the dataset or `"H5S_NULL"`. If an array, each integer
-                      value must be non-negative; if `maxdims` is supplied, the
-                      integer must also be less than the `maxdims` value for that
-                      dimension.
+                    Either an integer array giving the initial dimensions of
+                    the dataset or `"H5S_NULL"`. If an array, each integer
+                    value must be non-negative; if `maxdims` is supplied, the
+                    integer must also be less than the `maxdims` value for that
+                    dimension.
 
-                      If shape is `H5S_NULL`, a dataset will be created which
-                      can have a type and attributes, but unable to hold any
-                      data.
+                    If shape is `H5S_NULL`, a dataset will be created which
+                    can have a type and attributes, but unable to hold any
+                    data.
 
-                      If `shape` is omitted or empty (`[]`), will create a scalar
-                      dataset -- dataset comprised of a single entity.
+                    If `shape` is omitted or empty (`[]`), will create a scalar
+                    dataset -- dataset comprised of a single entity.
                   type: string
                   example: [128, 64]
                 maxdims:
                   description: >
-                      Integer array diving the maximum allowed extent for each
-                      dimension.
+                    Integer array diving the maximum allowed extent for each
+                    dimension.
 
-                      If a dimension's maxdim is `0`, the maximum extent is
-                      unlimited.
+                    If a dimension's maxdim is `0`, the maximum extent is
+                    unlimited.
                   type: array
                   items:
                     type: number
@@ -1113,30 +1067,30 @@ paths:
                   type: object
                 link:
                   description: >
-                      Optional JSON object to immediately create a hard Link to
-                      the newly-created object. If present, both `id` and `name`
-                      must be supplied and `id` must be the UUID of an existing
-                      Group -- UUID of any non-Group object will result in an
-                      error.
+                    Optional JSON object to immediately create a hard Link to
+                    the newly-created object. If present, both `id` and `name`
+                    must be supplied and `id` must be the UUID of an existing
+                    Group -- UUID of any non-Group object will result in an
+                    error.
 
-                      Note that the id reference is _reverse_ the usual for Link
-                      creation: the `id` value refers to the targeting object,
-                      not the target object of the link.
+                    Note that the id reference is _reverse_ the usual for Link
+                    creation: the `id` value refers to the targeting object,
+                    not the target object of the link.
                   type: object
                   required:
                     - id
                     - name
                   properties:
                     id:
-                      description: 'UUID of Group to link from.'
+                      description: "UUID of Group to link from."
                       type: string
-                      example: 'g-a613ed48-2c86-11e8-9391-0242ac110009'
+                      example: "g-a613ed48-2c86-11e8-9391-0242ac110009"
                     name:
                       description: Title of Link.
                       type: string
-                      example: 'dset2'
+                      example: "dset2"
       responses:
-        '201':
+        "201":
           description: Dataset created.
           content:
             application/json:
@@ -1155,7 +1109,7 @@ paths:
                     type: number
                   attributeCount:
                     type: number
-                  'type':
+                  "type":
                     description: (See `GET /datasets/{id}`)
                     type: object
                   shape:
@@ -1170,14 +1124,13 @@ paths:
         - Dataset
       summary: List Datasets.
       description: >
-          Only includes Datasets that are part of the tree linked to the root
-          Group in the Domain.
+        Only includes Datasets that are part of the tree linked to the root
+        Group in the Domain.
       parameters:
-        - $ref: '#/components/parameters/query_domain'
-        - $ref: '#/components/parameters/accept_json'
-        - $ref: '#/components/parameters/authorization'
+        - $ref: "#/components/parameters/query_domain"
+        - $ref: "#/components/parameters/authorization"
       responses:
-        '200':
+        "200":
           description: OK
           content:
             application/json:
@@ -1189,18 +1142,18 @@ paths:
                     items:
                       description: UUID of each Dataset.
                       type: string
-                      example: 'd-21ae0bbe-2dea-11e8-9391-0242ac110009'
+                      example: "d-21ae0bbe-2dea-11e8-9391-0242ac110009"
                   hrefs:
                     type: array
                     description: >
-                        List of references to other objects.
+                      List of references to other objects.
 
-                        Should contain references for:
-                        `attributes`,
-                        `data`,
-                        `home`,
-                        `root`,
-                        `self`
+                      Should contain references for:
+                      `attributes`,
+                      `data`,
+                      `home`,
+                      `root`,
+                      `self`
                     items:
                       type: object
                       properties:
@@ -1211,34 +1164,32 @@ paths:
                           description: Relation to this object.
                           type: string
                     example:
-                      - rel: 'attributes'
-                        href: 'http://localhost:5101/datasets/d-d257f938-3854-11e8-a123-0242ac110009/attributes?domain=/home/test_user_1/file'
-                      - rel': 'data'
-                        href: 'http://localhost:5101/datasets/d-d257f938-3854-11e8-a123-0242ac110009/value?domain=/home/test_user_1/file'
-                      - rel: 'home'
-                        href: 'http://localhost:5101/?domain=/home/test_user_1/file'
-                      - rel: 'root'
-                        href: 'http://localhost:5101/groups/g-d20a1cc2-3854-11e8-a123-0242ac110009?domain=/home/test_user_1/file'
-                      - rel: 'self'
-                        href: 'http://localhost:5101/datasets/d-d257f938-3854-11e8-a123-0242ac110009?domain=/home/test_user_1/file'
+                      - rel: "attributes"
+                        href: "http://localhost:5101/datasets/d-d257f938-3854-11e8-a123-0242ac110009/attributes?domain=/home/test_user_1/file"
+                      - rel': "data"
+                        href: "http://localhost:5101/datasets/d-d257f938-3854-11e8-a123-0242ac110009/value?domain=/home/test_user_1/file"
+                      - rel: "home"
+                        href: "http://localhost:5101/?domain=/home/test_user_1/file"
+                      - rel: "root"
+                        href: "http://localhost:5101/groups/g-d20a1cc2-3854-11e8-a123-0242ac110009?domain=/home/test_user_1/file"
+                      - rel: "self"
+                        href: "http://localhost:5101/datasets/d-d257f938-3854-11e8-a123-0242ac110009?domain=/home/test_user_1/file"
         default:
           description: Operation unsuccessful.
 
   # end '/datasets'
 
   /datasets/{id}:
-
     get:
       tags:
         - Dataset
       summary: Get information about a Dataset.
       parameters:
-        - $ref: '#/components/parameters/path_dataset_uuid'
-        - $ref: '#/components/parameters/query_domain'
-        - $ref: '#/components/parameters/accept_json'
-        - $ref: '#/components/parameters/authorization'
+        - $ref: "#/components/parameters/path_dataset_uuid"
+        - $ref: "#/components/parameters/query_domain"
+        - $ref: "#/components/parameters/authorization"
       responses:
-        '200':
+        "200":
           description: OK
           content:
             application/json:
@@ -1248,14 +1199,14 @@ paths:
                   id:
                     description: UUID of this Dataset.
                     type: string
-                    example: 'd-21ae0bbe-2dea-11e8-9391-0242ac110009'
+                    example: "d-21ae0bbe-2dea-11e8-9391-0242ac110009"
                   root:
                     description: UUID of root Group in Domain.
                     type: string
-                    example: 'g-d313d498-2de4-11e8-9391-0242ac110009'
+                    example: "g-d313d498-2de4-11e8-9391-0242ac110009"
                   domain:
                     type: string
-                    example: '/home/test_user1/file'
+                    example: "/home/test_user1/file"
                   created:
                     type: number
                     example: 1521734424.3
@@ -1265,14 +1216,14 @@ paths:
                   attributeCount:
                     type: number
                     example: 0
-                  'type':
+                  "type":
                     description: TODO
                     type: object
                     properties:
                       class:
                         type: string
                         description: >
-                            TODO
+                          TODO
                         enum:
                           - H5T_COMPOUND
                           - H5T_FLOAT
@@ -1280,14 +1231,14 @@ paths:
                       base:
                         type: string
                         description: >
-                            TODO
+                          TODO
 
-                            Only present if class is not `H5T_COMPUND`.
+                          Only present if class is not `H5T_COMPUND`.
                       fields:
                         description: >
-                            List of fields in a compound dataset.
+                          List of fields in a compound dataset.
 
-                            Only present if `class` is `H5T_COMPOUND`.
+                          Only present if `class` is `H5T_COMPOUND`.
                         type: array
                         items:
                           type: object
@@ -1295,13 +1246,13 @@ paths:
                             name:
                               type: string
                               description: >
-                                  Descriptive or identifying name.
-                                  Must be unique in the fields list.
+                                Descriptive or identifying name.
+                                Must be unique in the fields list.
                             type:
                               type: string
                               description: >
-                                  Enum of pre-defined type, UUID of committed type,
-                                  or type definition. (TODO: see `POST Dataset`?)
+                                Enum of pre-defined type, UUID of committed type,
+                                or type definition. (TODO: see `POST Dataset`?)
                     example:
                       base: H5T_STD_U32LE
                       class: H5T_INTEGER
@@ -1312,14 +1263,14 @@ paths:
                       class:
                         type: string
                         description: >
-                            String enum indicating expected structure.
+                          String enum indicating expected structure.
 
-                            + H5S_NULL -- Dataset has no data and no shape.
+                          + H5S_NULL -- Dataset has no data and no shape.
 
-                            + H5S_SCALAR -- Single entity as the Datast.
+                          + H5S_SCALAR -- Single entity as the Datast.
 
-                            + H5S_SIMPLE -- Dataset has hyperrectangular shape of
-                              one or more dimensions.
+                          + H5S_SIMPLE -- Dataset has hyperrectangular shape of
+                            one or more dimensions.
                         enum:
                           - H5S_NULL
                           - H5S_SCALAR
@@ -1327,21 +1278,21 @@ paths:
                       dims:
                         type: array
                         description: >
-                            Extent of each dimension in Dataset.
+                          Extent of each dimension in Dataset.
 
-                            Only present if `class` is `H5S_SIMPLE`.
+                          Only present if `class` is `H5S_SIMPLE`.
                         items:
                           type: number
                       maxdims:
                         type: array
                         description: >
-                            Maximum possible extent for each dimension.
+                          Maximum possible extent for each dimension.
 
-                            Value of `0` in array indicates that the dimension has
-                            unlimited maximum extent.
+                          Value of `0` in array indicates that the dimension has
+                          unlimited maximum extent.
 
-                            Only present if `class` is `H5S_SIMPLE`, and
-                            `maxdims` was included upon Dataset creation.
+                          Only present if `class` is `H5S_SIMPLE`, and
+                          `maxdims` was included upon Dataset creation.
                         items:
                           type: number
                     example:
@@ -1356,17 +1307,17 @@ paths:
                       class: H5D_CHUNKED
                   creationProperties:
                     description: >
-                        Dataset creation properties as provided upon creation.
+                      Dataset creation properties as provided upon creation.
                     type: object
                   hrefs:
                     description: >
-                        List of references to other objects.
+                      List of references to other objects.
 
-                        Must include references to only:
-                        `attributes`,
-                        `data` (shape class `H5S_NULL` must _not_ include `data`),
-                        `root`,
-                        `self`.
+                      Must include references to only:
+                      `attributes`,
+                      `data` (shape class `H5S_NULL` must _not_ include `data`),
+                      `root`,
+                      `self`.
                     type: array
                     items:
                       type: object
@@ -1385,18 +1336,17 @@ paths:
         - Dataset
       summary: Delete a Dataset.
       description: >
-          Links to this Dataset are not deleted.
+        Links to this Dataset are not deleted.
 
-          TODO: Attributes and commited types are not deleted.
+        TODO: Attributes and commited types are not deleted.
       parameters:
-        - $ref: '#/components/parameters/path_dataset_uuid'
-        - $ref: '#/components/parameters/query_domain'
-        - $ref: '#/components/parameters/accept_json'
-        - $ref: '#/components/parameters/authorization'
+        - $ref: "#/components/parameters/path_dataset_uuid"
+        - $ref: "#/components/parameters/query_domain"
+        - $ref: "#/components/parameters/authorization"
       responses:
-        '200':
+        "200":
           description: >
-              Dataset deleted. Always returns empty object `{}`.
+            Dataset deleted. Always returns empty object `{}`.
           content:
             application/json:
               schema:
@@ -1407,31 +1357,29 @@ paths:
   # end /datasets/{id}
 
   /datasets/{id}/shape:
-
     put:
       tags:
         - Dataset
       summary: Modify a Dataset's dimensions.
       description: >
-          Only datasets with `maxdims` may be resized.
+        Only datasets with `maxdims` may be resized.
 
-          Dataset may not shrink (TODO).
+        Dataset may not shrink (TODO).
       parameters:
-        - $ref: '#/components/parameters/path_dataset_uuid'
-        - $ref: '#/components/parameters/query_domain'
-        - $ref: '#/components/parameters/accept_json'
-        - $ref: '#/components/parameters/authorization'
+        - $ref: "#/components/parameters/path_dataset_uuid"
+        - $ref: "#/components/parameters/query_domain"
+        - $ref: "#/components/parameters/authorization"
       requestBody:
         required: true
         description: >
-            Array of nonzero integers.
+          Array of nonzero integers.
 
-            Length must equal Dataset's rank -- one value per dimension.
+          Length must equal Dataset's rank -- one value per dimension.
 
-            New extent must be greater than or equal to the current extent
-            and less than or equal to maximum extent (from `maxdims`).
-            For dimension index `i`, if `maxdims[i] == 0` then its maximum
-            extent is unbounded.
+          New extent must be greater than or equal to the current extent
+          and less than or equal to maximum extent (from `maxdims`).
+          For dimension index `i`, if `maxdims[i] == 0` then its maximum
+          extent is unbounded.
         content:
           application/json:
             schema:
@@ -1444,11 +1392,11 @@ paths:
                   items:
                     type: number
       responses:
-        '201':
+        "201":
           description: >
-              Shape dimensions updated.
+            Shape dimensions updated.
 
-              Always returns `{"hrefs": []}` upon success.
+            Always returns `{"hrefs": []}` upon success.
           content:
             application/json:
               schema:
@@ -1468,19 +1416,19 @@ paths:
         - Dataset
       summary: Get information about a Dataset's shape.
       parameters:
-        - $ref: '#/components/parameters/path_dataset_uuid'
-        - $ref: '#/components/parameters/query_domain'
-        - $ref: '#/components/parameters/accept_json'
-        - $ref: '#/components/parameters/authorization'
+        - $ref: "#/components/parameters/path_dataset_uuid"
+        - $ref: "#/components/parameters/query_domain"
+
+        - $ref: "#/components/parameters/authorization"
       responses:
-        '200':
+        "200":
           description: OK
           content:
             application/json:
               schema:
                 type: object
                 description: >
-                    (See `GET /datasets/{id}`)
+                  (See `GET /datasets/{id}`)
                 properties:
                   created:
                     type: number
@@ -1491,10 +1439,10 @@ paths:
                   hrefs:
                     type: array
                     description: >
-                        Must include references to only:
-                        `owner`,
-                        `root`,
-                        `self`.
+                      Must include references to only:
+                      `owner`,
+                      `root`,
+                      `self`.
                     items:
                       type: object
                       properties:
@@ -1514,19 +1462,18 @@ paths:
         - Dataset
       summary: Get information about a Dataset's type.
       parameters:
-        - $ref: '#/components/parameters/path_dataset_uuid'
-        - $ref: '#/components/parameters/query_domain'
-        - $ref: '#/components/parameters/accept_json'
-        - $ref: '#/components/parameters/authorization'
+        - $ref: "#/components/parameters/path_dataset_uuid"
+        - $ref: "#/components/parameters/query_domain"
+        - $ref: "#/components/parameters/authorization"
       responses:
-        '200':
+        "200":
           description: OK
           content:
             application/json:
               schema:
                 type: object
                 description: >
-                    (See `GET /datasets/{id}`)
+                  (See `GET /datasets/{id}`)
                 properties:
                   type:
                     type: object
@@ -1551,101 +1498,99 @@ paths:
   #end /datasets/{id}/type
 
   /datasets/{id}/value:
-
     put:
       tags:
         - Dataset
       summary: Write values to Dataset.
       description: Overwrites any existing data in update region.
       parameters:
-        - $ref: '#/components/parameters/path_dataset_uuid'
-        - $ref: '#/components/parameters/query_domain'
-        - $ref: '#/components/parameters/accept_json'
-        - $ref: '#/components/parameters/authorization'
-        - $ref: '#/components/parameters/content_json_only'
+        - $ref: "#/components/parameters/path_dataset_uuid"
+        - $ref: "#/components/parameters/query_domain"
+        - $ref: "#/components/parameters/authorization"
+
       requestBody:
         required: true
         description: >
-            JSON object describing what to write.
+          JSON object describing what to write.
 
-            At least one of `points` OR `start, stop, step` must be provided.
+          At least one of `points` OR `start, stop, step` must be provided.
 
-            `value` must be provided if not using `points`, else _either_
-            `value` or `value_bas64` must be provided.
+          `value` must be provided if not using `points`, else _either_
+          `value` or `value_bas64` must be provided.
         content:
           application/json:
-              schema:
-                type: object
-                properties:
-                  start:
-                    description: >
-                        Start coordinate of update.
+            schema:
+              type: object
+              properties:
+                start:
+                  description: >
+                    Start coordinate of update.
 
-                        Each coordinate value must be non-negative and less than
-                        the extent of the dimension.
+                    Each coordinate value must be non-negative and less than
+                    the extent of the dimension.
 
-                        Default start value is 0 for each dimension.
-                    type: array
-                    items:
-                      type: number
-                  stop:
-                    description: >
-                        End coordinate of update.
+                    Default start value is 0 for each dimension.
+                  type: array
+                  items:
+                    type: number
+                stop:
+                  description: >
+                    End coordinate of update.
 
-                        Each coordinate value must be greater than `start` and less
-                        than the dimension's extent.
-                    type: array
-                    items:
-                      type: number
-                  step:
-                    description: >
-                        Coordinate increment step for each dimension.
-                    type: array
-                    items:
-                      type: number
-                  points:
-                    description: >
-                        List of coordinate points to update.
+                    Each coordinate value must be greater than `start` and less
+                    than the dimension's extent.
+                  type: array
+                  items:
+                    type: number
+                step:
+                  description: >
+                    Coordinate increment step for each dimension.
+                  type: array
+                  items:
+                    type: number
+                points:
+                  description: >
+                    List of coordinate points to update.
 
-                        Overrides `start`, `stop`, and `step`.
+                    Overrides `start`, `stop`, and `step`.
 
-                        If dataset is of rank 1 (single-dimension), each item
-                        should be an integer index not less than zero and less than
-                        the extent of the dataset.
+                    If dataset is of rank 1 (single-dimension), each item
+                    should be an integer index not less than zero and less than
+                    the extent of the dataset.
 
-                        If dataset is multi-dimensional, each item should be a list
-                        of non-negative integers, each array being a valid
-                        coordinate in the dataset.
+                    If dataset is multi-dimensional, each item should be a list
+                    of non-negative integers, each array being a valid
+                    coordinate in the dataset.
 
-                        Number of elements in list should equal that of `value`.
+                    Number of elements in list should equal that of `value`.
 
-                        TODO: scalar dataset?
-                    type: array
-                    items:
-                      type: string
-                    example: [[4,3,1], [6,1,2], [12,0,0]]
-                  value:
-                    description: >
-                        JSON array containing values to write.
-
-                        (TODO: 'anything in array' may give Swagger some grief.)
-                    type: array
-                    items:
-                      type: string # TODO: not really...
-                    example: [323, 16, 44]
-                  value_base64:
-                    description: >
-                        Base64-encoded binary data.
-
-                        Use instead of `value` for more efficient large data
-                        transfers.
-
-                        Only supported for fixed-length datatypes.
+                    TODO: scalar dataset?
+                  type: array
+                  items:
                     type: string
-                required:
-                  - value
+                  example: [[4, 3, 1], [6, 1, 2], [12, 0, 0]]
+                value:
+                  description: >
+                    JSON array containing values to write.
+
+                    (TODO: 'anything in array' may give Swagger some grief.)
+                  type: array
+                  items:
+                    type: string # TODO: not really...
+                  example: [323, 16, 44]
+                value_base64:
+                  description: >
+                    Base64-encoded binary data.
+
+                    Use instead of `value` for more efficient large data
+                    transfers.
+
+                    Only supported for fixed-length datatypes.
+                  type: string
+              required:
+                - value
       responses:
-        '200':
+        "200":
           description: Update/write successful.
         default:
           description: Operation unsuccessful.
@@ -1656,184 +1601,159 @@ paths:
       summary: Get values from Dataset.
       description: Either get the entire Dataset or a selection.
       parameters:
-        - $ref: '#/components/parameters/path_dataset_uuid'
-        - $ref: '#/components/parameters/query_domain'
+        - $ref: "#/components/parameters/path_dataset_uuid"
+        - $ref: "#/components/parameters/query_domain"
         - name: select
           in: query
           schema:
             type: string
           description: >
-              URL-encoded string representing a selection array.
+            URL-encoded string representing a selection array.
 
-              _Example_: `[3:9,0:5:2]`
-              gets values from two-dimensional dataset:
-              [[3,0], [4,0], ..., [8,0], [3,2], [4,2], ..., [8,4]]
-              (18 data points total: `6*3`)
+            _Example_: `[3:9,0:5:2]`
+            gets values from two-dimensional dataset:
+            [[3,0], [4,0], ..., [8,0], [3,2], [4,2], ..., [8,4]]
+            (18 data points total: `6*3`)
 
-              In EBNF plaintext:
+            In EBNF plaintext:
 
-              `SELECT` := `'[' SLICE { ',' SLICE } ']'`
+            `SELECT` := `'[' SLICE { ',' SLICE } ']'`
 
-              `SLICE` := `START ':' STOP [ ':' STEP ]`
+            `SLICE` := `START ':' STOP [ ':' STEP ]`
 
-              `START` := non-negative integer less than the dimension's
-              extent.
+            `START` := non-negative integer less than the dimension's
+            extent.
 
-              `STOP` := non-negaive integer greater than `START` and less than
-              or equal to the dimension's extent. Is the first index _not_
-              included in the selection hyperslab.
+            `STOP` := non-negaive integer greater than `START` and less than
+            or equal to the dimension's extent. Is the first index _not_
+            included in the selection hyperslab.
 
-              `STEP` := non-negative integer greater than zero; is the
-              increment of index in dimension between each value. If omitted,
-              defaults to `1` (contiguous indices).
+            `STEP` := non-negative integer greater than zero; is the
+            increment of index in dimension between each value. If omitted,
+            defaults to `1` (contiguous indices).
         - name: query
           in: query
           schema:
             type: string
           description: >
-              URL-encoded string of conditional expression to filter selection.
+            URL-encoded string of conditional expression to filter selection.
 
-              E.g., the condition `(temp > 32.0) & (dir == 'N')` would return
-              elements of the dataset where the `temp` field was greater than
-              `32.0` _and_ the `dir` field was equal to `N`.
-              TODO: query syntax description
+            E.g., the condition `(temp > 32.0) & (dir == 'N')` would return
+            elements of the dataset where the `temp` field was greater than
+            `32.0` _and_ the `dir` field was equal to `N`.
+            TODO: query syntax description
 
-              _Must_ be URL-encoded.
+            _Must_ be URL-encoded.
 
-              Can be used in conjunction with `select` parameter to filter
-              a hyberslab selection. Can be used in conjunction with `Limit`
-              parameter to restrict number of values returned.
+            Can be used in conjunction with `select` parameter to filter
+            a hyberslab selection. Can be used in conjunction with `Limit`
+            parameter to restrict number of values returned.
 
-              Only applicable to one-dimensional compound datasets.
-              TODO: verify
+            Only applicable to one-dimensional compound datasets.
+            TODO: verify
         - name: Limit
           in: query
           schema:
             type: number
           description: >
-              Integer greater than zero.
+            Integer greater than zero.
 
-              If present, specifies maximum number of values to return.
+            If present, specifies maximum number of values to return.
 
-              Apples only to the `query` parameter.
-        - name: Accept
-          in: header
-          schema:
-            type: string
-            enum:
-              - application/json
-              - application/octet-stream
-            default: application/json
-          description: >
-              If expecting a binary data response, use
-              `application/octet-stream` in place of the usual
-              `application/json`
+            Applies only to the `query` parameter.
 
-              Binary data responses are only supported for datasets with
-              fixed-length type. Binary response will consist of the equivalent
-              binary data of the `data` item in the JSON response -- no data
-              representing `hrefs` is returned.
-
-              Verify return type with the `Content-Type` response header.
-        - $ref: '#/components/parameters/authorization'
-## WISHLIST: Remove parameters from URI and fold in 'POST DATASET' with
-##           a single request body format:
-##type: object:
-##properties:
-##  points:
-##    description: >
-##        Specific data points to return from the Dataset.
-##
-##        Overrides any other selection element.
-##    type: array # array of points/coordinates in dataset
-##    items:
-##      type: array # index in each dimension for point.
-##                  # length must equal dataset rank.
-##      items:
-##        type: number # 0 <= N < dimension extent
-##  select:
-##    description: >
-##        Coordinate ranges or strides defining a hyberslab subset of Dataset.
-##
-##        Array length must equal rank of Dataset.
-##        Empty range object, `{}`, stands in for entire dimension.
-##    type: array
-##    items:
-##      type: object
-##      properties:
-##        start:
-##          description: >
-##              Integer greater than or equal to `0` and less than extent.
-##
-##              Default `0`.
-##          type: number
-##        stop:
-##          description: >
-##              Integer greater than `start` and less than or equal to extent.
-##
-##              First index _not_ included in selection hyperslab.
-##
-##              Default dimension extent. (`-1`?)
-##          type: number
-##        step:
-##          description: Positive, non-zero integer. Default `1`.
-##          type: number
-##    example: # array of 'objects'
-##      - {}
-##      - {"start": 3, "stop": 19, "step": 4}
-##      - {"stop": 10, "step: 3}
-##      - {"start": 126}
-##    # would get [[0,1,..,n], [3,7,11,15], [0,3,6,9], [126,127,..,n]]
-##  query:
-##    description: >
-##        Filter response values (even from hyperslab selection).
-##    type: object
-##    properties:
-##      condition:
-##        description: >
-##            String describing contitions required to include the value in
-##            response. E.g., `"(temp > 32.0) & (dir == 'N')"` would return
-##            elements of the dataset where the `temp` field was greater than
-##            `32.0` and the `dir` field was equal to `N`.
-##        type: string
-##      limit:
-##        description: Integer greater than 0, maximum number of values to get.
-##        type: number
+        - $ref: "#/components/parameters/authorization"
+      ## WISHLIST: Remove parameters from URI and fold in 'POST DATASET' with
+      ##           a single request body format:
+      ##type: object:
+      ##properties:
+      ##  points:
+      ##    description: >
+      ##        Specific data points to return from the Dataset.
+      ##
+      ##        Overrides any other selection element.
+      ##    type: array # array of points/coordinates in dataset
+      ##    items:
+      ##      type: array # index in each dimension for point.
+      ##                  # length must equal dataset rank.
+      ##      items:
+      ##        type: number # 0 <= N < dimension extent
+      ##  select:
+      ##    description: >
+      ##        Coordinate ranges or strides defining a hyberslab subset of Dataset.
+      ##
+      ##        Array length must equal rank of Dataset.
+      ##        Empty range object, `{}`, stands in for entire dimension.
+      ##    type: array
+      ##    items:
+      ##      type: object
+      ##      properties:
+      ##        start:
+      ##          description: >
+      ##              Integer greater than or equal to `0` and less than extent.
+      ##
+      ##              Default `0`.
+      ##          type: number
+      ##        stop:
+      ##          description: >
+      ##              Integer greater than `start` and less than or equal to extent.
+      ##
+      ##              First index _not_ included in selection hyperslab.
+      ##
+      ##              Default dimension extent. (`-1`?)
+      ##          type: number
+      ##        step:
+      ##          description: Positive, non-zero integer. Default `1`.
+      ##          type: number
+      ##    example: # array of 'objects'
+      ##      - {}
+      ##      - {"start": 3, "stop": 19, "step": 4}
+      ##      - {"stop": 10, "step: 3}
+      ##      - {"start": 126}
+      ##    # would get [[0,1,..,n], [3,7,11,15], [0,3,6,9], [126,127,..,n]]
+      ##  query:
+      ##    description: >
+      ##        Filter response values (even from hyperslab selection).
+      ##    type: object
+      ##    properties:
+      ##      condition:
+      ##        description: >
+      ##            String describing contitions required to include the value in
+      ##            response. E.g., `"(temp > 32.0) & (dir == 'N')"` would return
+      ##            elements of the dataset where the `temp` field was greater than
+      ##            `32.0` and the `dir` field was equal to `N`.
+      ##        type: string
+      ##      limit:
+      ##        description: Integer greater than 0, maximum number of values to get.
+      ##        type: number
       responses:
-        '200':
+        "200":
           description: OK
-          # headers:
-          #   'Content-Type':
-          #     description: >
-          #         MIME type of response.
-
-          #         Normally 'application/json' but can be
-          #         'application/octet-stream' if binary data response was
-          #         requested.
-          #     type: string
-          # Commented above because of https://spec.openapis.org/oas/v3.0.0#fixed-fields-14
           content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
             application/json:
               schema:
                 type: object
                 properties:
                   index:
                     description: >
-                        List of indices (TODO: coordinates?) corresponding with
-                        each value returned. i.e., `index[i]` is the coordinate of
-                        `value[i]`.
+                      List of indices (TODO: coordinates?) corresponding with
+                      each value returned. i.e., `index[i]` is the coordinate of
+                      `value[i]`.
 
-                        Only present if `query` parameter is part of the request
-                        URI.
+                      Only present if `query` parameter is part of the request
+                      URI.
                     type: array
                     items:
                       type: string # TODO: integer or array of integers WISHLIST: arrays
                     example: [0, 1, 2, 3, 4, 5, 6, 7]
                   values:
                     type: array
-                    items:
-                      type: string # TODO: placeholder for 'any JSON, really'
-                    example:  # yaml syntax for easy-readable array of arrays
+                    items: {}
+                    example: # yaml syntax for easy-readable array of arrays
                       - [1, 3, 5, 7]
                       - [2, 6, 10, 14]
                       - [3, 9, 15, 21]
@@ -1849,12 +1769,11 @@ paths:
       tags:
         - Dataset
       summary: Get specific data points from Dataset.
-# TODO: WISHLIST: fold into GET DATASET; 'POST' is counterintuitive.
+      # TODO: WISHLIST: fold into GET DATASET; 'POST' is counterintuitive.
       parameters:
-        - $ref: '#/components/parameters/path_dataset_uuid'
-        - $ref: '#/components/parameters/query_domain'
-        - $ref: '#/components/parameters/accept_json'
-        - $ref: '#/components/parameters/authorization'
+        - $ref: "#/components/parameters/path_dataset_uuid"
+        - $ref: "#/components/parameters/query_domain"
+        - $ref: "#/components/parameters/authorization"
       requestBody:
         description: JSON array of coordinates in the Dataset.
         required: true
@@ -1866,12 +1785,12 @@ paths:
                 points:
                   type: array
                   items:
-                    type: array  # TODO: verify array of arrays; esp. in single-coordinate case... [[5,3]], vs [5,3]
+                    type: array # TODO: verify array of arrays; esp. in single-coordinate case... [[5,3]], vs [5,3]
                     items:
                       type: number
-                  example: [[0,0], [0,1], [1,0], [1,1]]
+                  example: [[0, 0], [0, 1], [1, 0], [1, 1]]
       responses:
-        '200':
+        "200":
           description: OK
           content:
             application/json:
@@ -1880,8 +1799,7 @@ paths:
                 properties:
                   value:
                     type: array
-                    items:
-                      type: string # TODO: any value
+                    items: {}
                     example: [0, 1, 1, 2]
         default:
           description: Operation unsuccessful.
@@ -1889,19 +1807,17 @@ paths:
   #end /datasets/{id}/value
 
   /datatypes:
-
-    'post':
+    "post":
       tags:
         - Domain
         - Datatype
       summary: Commit a Datatype to the Domain.
       parameters:
-        - $ref: '#/components/parameters/query_domain'
-        - $ref: '#/components/parameters/accept_json'
-        - $ref: '#/components/parameters/authorization'
+        - $ref: "#/components/parameters/query_domain"
+        - $ref: "#/components/parameters/authorization"
       requestBody:
         description: >
-            Definition of Datatype to commit.
+          Definition of Datatype to commit.
         required: true
         content:
           application/json:
@@ -1912,16 +1828,15 @@ paths:
                   type: string
                 type:
                   description: >
-                      _Can be a string enum of a predefined type_, e.g.,
-                      `H5T_STD_U32LE` or `H5T_IEEE_F64LE`.
+                    _Can be a string enum of a predefined type_, e.g.,
+                    `H5T_STD_U32LE` or `H5T_IEEE_F64LE`.
                   type: object
                   properties:
                     class:
                       type: string
                       description: >
-                          Must be "H5T_COMPOUND"?
-                      example:
-                        H5T_COMPOUND
+                        Must be "H5T_COMPOUND"?
+                      example: H5T_COMPOUND
                     fields:
                       type: array
                       items:
@@ -1929,13 +1844,13 @@ paths:
                         properties:
                           name:
                             description: >
-                                Identifier of the field.
+                              Identifier of the field.
                             type: string
-                          'type':
+                          "type":
                             description: >
-                                Type of the field.
+                              Type of the field.
 
-                                TODO: pre-defined enum string vs type object?
+                              TODO: pre-defined enum string vs type object?
                             type: string
                       example:
                         - name: temp
@@ -1943,7 +1858,7 @@ paths:
                         - name: pressure
                           type: "H5T_IEEE_F32LE"
       responses:
-        '201':
+        "201":
           description: CREATED
           content:
             application/json:
@@ -1958,11 +1873,11 @@ paths:
         default:
           description: Operation unsuccessful.
 
-#    get: # TODO: not present in tests or elsewhere
-#      tags:
-#        - Domain
-#        - Datatype
-#      summary: Get a list of Datatypes committed on Domain.
+  #    get: # TODO: not present in tests or elsewhere
+  #      tags:
+  #        - Domain
+  #        - Datatype
+  #      summary: Get a list of Datatypes committed on Domain.
 
   # end /datatypes
 
@@ -1972,12 +1887,11 @@ paths:
         - Datatype
       summary: Get information about a committed Datatype
       parameters:
-        - $ref: '#/components/parameters/query_domain'
-        - $ref: '#/components/parameters/path_datatype_uuid'
-        - $ref: '#/components/parameters/accept_json'
-        - $ref: '#/components/parameters/authorization'
+        - $ref: "#/components/parameters/query_domain"
+        - $ref: "#/components/parameters/path_datatype_uuid"
+        - $ref: "#/components/parameters/authorization"
       responses:
-        '200':
+        "200":
           description: OK
           content:
             application/json:
@@ -2017,18 +1931,17 @@ paths:
         - Datatype
       summary: Delete a committed Datatype.
       parameters:
-        - $ref: '#/components/parameters/query_domain'
-        - $ref: '#/components/parameters/path_datatype_uuid'
-        - $ref: '#/components/parameters/accept_json'
-        - $ref: '#/components/parameters/authorization'
+        - $ref: "#/components/parameters/query_domain"
+        - $ref: "#/components/parameters/path_datatype_uuid"
+        - $ref: "#/components/parameters/authorization"
       responses:
-        '200':
+        "200":
           description: OK
           content:
             application/json:
               schema:
                 type: object
-                description: "Always returns `{\"hrefs\": []}` (TODO confirm)"
+                description: 'Always returns `{"hrefs": []}` (TODO confirm)'
                 properties:
                   hrefs:
                     type: array
@@ -2048,7 +1961,6 @@ paths:
   # end /datatypes/{id}
 
   /{collection}/{obj_uuid}/attributes:
-
     get:
       tags:
         - Attribute
@@ -2058,8 +1970,7 @@ paths:
       summary: List all Attributes attached to the HDF5 object `obj_uuid`.
       description: Attributes sorted alphanumerically by name.
       parameters:
-        - $ref: '#/components/parameters/accept_json'
-        - $ref: '#/components/parameters/authorization'
+        - $ref: "#/components/parameters/authorization"
         - name: collection
           in: path
           description: "The collection of the HDF5 object (one of: `groups`, `datasets`, or `datatypes`)."
@@ -2077,30 +1988,30 @@ paths:
             type: string
             format: uuid
           required: true
-        - $ref: '#/components/parameters/query_domain'
+        - $ref: "#/components/parameters/query_domain"
         - name: Limit
           in: query
           description: >
-              Cap the number of Attributes listed.
+            Cap the number of Attributes listed.
 
-              Can be used with `Marker`.
+            Can be used with `Marker`.
           schema:
             type: number
         - name: Marker
           in: query
           description: >
-              Start Attribute listing _after_ the given name.
+            Start Attribute listing _after_ the given name.
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: OK
           content:
             application/json:
               schema:
                 type: object
                 description: >
-                    TODO
+                  TODO
                 properties:
                   attributes:
                     type: array
@@ -2145,9 +2056,8 @@ paths:
         - Datatype
       summary: Create an attribute with name `attr` and assign it to HDF5 object `obj_uudi`.
       parameters:
-        - $ref: '#/components/parameters/accept_json'
-        - $ref: '#/components/parameters/authorization'
-        - $ref: '#/components/parameters/query_domain'
+        - $ref: "#/components/parameters/authorization"
+        - $ref: "#/components/parameters/query_domain"
         - name: collection
           required: true
           in: path
@@ -2176,28 +2086,28 @@ paths:
         content:
           application/json:
             schema:
-              type: object  # TODO: Put a real definition.
+              type: object # TODO: Put a real definition.
       responses:
-        '200':
+        "200":
           description: OK
           content:
             application/json:
               schema:
                 type: object
                 description: TODO
-#            properties: # TODO: not specified in tests or elsewhere.
-#              hrefs:
-#                type: array
-#                items:
-#                  type: object
-#                  properties:
-#                    href:
-#                      type: string
-#                      description: URL of resource
-#                    rel:
-#                      type: string
-#                      description: relation to this object
-#                example: []
+        #            properties: # TODO: not specified in tests or elsewhere.
+        #              hrefs:
+        #                type: array
+        #                items:
+        #                  type: object
+        #                  properties:
+        #                    href:
+        #                      type: string
+        #                      description: URL of resource
+        #                    rel:
+        #                      type: string
+        #                      description: relation to this object
+        #                example: []
         default:
           description: Operation unsuccessful.
 
@@ -2209,9 +2119,8 @@ paths:
         - Datatype
       summary: Get information about an Attribute.
       parameters:
-        - $ref: '#/components/parameters/accept_json'
-        - $ref: '#/components/parameters/authorization'
-        - $ref: '#/components/parameters/query_domain'
+        - $ref: "#/components/parameters/authorization"
+        - $ref: "#/components/parameters/query_domain"
         - name: collection
           in: path
           description: Collection of object (Group, Dataset, or Datatype).
@@ -2237,14 +2146,14 @@ paths:
             pattern: ^[^/]+$
           required: true
       responses:
-        '200':
+        "200":
           description: OK
           content:
             application/json:
               schema:
                 type: object
                 description: >
-                    TODO
+                  TODO
                 properties:
                   created:
                     type: number
@@ -2279,13 +2188,12 @@ paths:
         - ACLS
         - Domain
       summary: Get access lists on Domain.
-#      description: Attributes sorted alphanumerially by name. # TODO
+      #      description: Attributes sorted alphanumerially by name. # TODO
       parameters:
-        - $ref: '#/components/parameters/query_domain'
-        - $ref: '#/components/parameters/accept_json'
-        - $ref: '#/components/parameters/authorization'
+        - $ref: "#/components/parameters/query_domain"
+        - $ref: "#/components/parameters/authorization"
       responses:
-        '200':
+        "200":
           description: OK
           content:
             application/json:
@@ -2294,7 +2202,7 @@ paths:
                 description: TODO
                 properties:
                   acls:
-                    $ref: '#/components/schemas/ACLS'
+                    $ref: "#/components/schemas/ACLS"
                   hrefs:
                     type: array
                     items:
@@ -2319,9 +2227,8 @@ paths:
         - Domain
       summary: Get users's access to a Domain.
       parameters:
-        - $ref: '#/components/parameters/query_domain'
-        - $ref: '#/components/parameters/accept_json'
-        - $ref: '#/components/parameters/authorization'
+        - $ref: "#/components/parameters/query_domain"
+        - $ref: "#/components/parameters/authorization"
         - name: user
           required: true
           in: path
@@ -2329,7 +2236,7 @@ paths:
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: OK
           content:
             application/json:
@@ -2338,7 +2245,7 @@ paths:
                 description: TODO
                 properties:
                   acl:
-                    $ref: '#/components/schemas/ACL'
+                    $ref: "#/components/schemas/ACL"
                   hrefs:
                     type: array
                     items:
@@ -2362,11 +2269,11 @@ paths:
       requestBody:
         required: true
         description: >
-            JSON object with one or more keys from the set: 'create', 'read',
-            'update', 'delete', 'readACL', 'updateACL'.  Each key should have
-            a boolean value.  Based on keys provided, the user's ACL will be 
-            updated for those keys.  If no ACL exist for the given user, it
-            will be created.
+          JSON object with one or more keys from the set: 'create', 'read',
+          'update', 'delete', 'readACL', 'updateACL'.  Each key should have
+          a boolean value.  Based on keys provided, the user's ACL will be 
+          updated for those keys.  If no ACL exist for the given user, it
+          will be created.
         content:
           application/json:
             schema:
@@ -2391,12 +2298,11 @@ paths:
           schema:
             type: string
           required: true
-        - $ref: '#/components/parameters/query_domain'
-        - $ref: '#/components/parameters/accept_json'
-        - $ref: '#/components/parameters/authorization'
-         
+        - $ref: "#/components/parameters/query_domain"
+        - $ref: "#/components/parameters/authorization"
+
       responses:
-        '200':
+        "200":
           description: OK
           content:
             application/json:
@@ -2405,7 +2311,7 @@ paths:
                 description: TODO
                 properties:
                   acl:
-                    $ref: '#/components/schemas/ACL'
+                    $ref: "#/components/schemas/ACL"
                   hrefs:
                     type: array
                     items:
@@ -2424,20 +2330,18 @@ paths:
   # end /acls/{user}
 
   /groups/{id}/acls:
-
     get:
       tags:
         - ACLS
         - Group
       summary: List access lists on Group.
-#      description: Attributes sorted alphanumerially by name.
+      #      description: Attributes sorted alphanumerially by name.
       parameters:
-        - $ref: '#/components/parameters/path_group_uuid'
-        - $ref: '#/components/parameters/query_domain'
-        - $ref: '#/components/parameters/accept_json'
-        - $ref: '#/components/parameters/authorization'
+        - $ref: "#/components/parameters/path_group_uuid"
+        - $ref: "#/components/parameters/query_domain"
+        - $ref: "#/components/parameters/authorization"
       responses:
-        '200':
+        "200":
           description: OK
           content:
             application/json:
@@ -2446,7 +2350,7 @@ paths:
                 description: TODO
                 properties:
                   acls:
-                    $ref: '#/components/schemas/ACLS'
+                    $ref: "#/components/schemas/ACLS"
                   hrefs:
                     type: array
                     items:
@@ -2465,25 +2369,23 @@ paths:
   # end /groups/{id}/acls
 
   /groups/{id}/acls/{user}:
-
     get:
       tags:
         - ACLS
         - Group
       summary: Get users's access to a Group.
       parameters:
-        - $ref: '#/components/parameters/path_group_uuid'
+        - $ref: "#/components/parameters/path_group_uuid"
         - name: user
           in: path
           description: Identifier/name of a user.
           schema:
             type: string
           required: true
-        - $ref: '#/components/parameters/query_domain'
-        - $ref: '#/components/parameters/accept_json'
-        - $ref: '#/components/parameters/authorization'
+        - $ref: "#/components/parameters/query_domain"
+        - $ref: "#/components/parameters/authorization"
       responses:
-        '200':
+        "200":
           description: OK
           content:
             application/json:
@@ -2492,7 +2394,7 @@ paths:
                 description: TODO
                 properties:
                   acl:
-                    $ref: '#/components/schemas/ACL'
+                    $ref: "#/components/schemas/ACL"
                   hrefs:
                     type: array
                     items:
@@ -2517,12 +2419,11 @@ paths:
         - Dataset
       summary: Get access lists on Dataset.
       parameters:
-        - $ref: '#/components/parameters/path_dataset_uuid'
-        - $ref: '#/components/parameters/query_domain'
-        - $ref: '#/components/parameters/accept_json'
-        - $ref: '#/components/parameters/authorization'
+        - $ref: "#/components/parameters/path_dataset_uuid"
+        - $ref: "#/components/parameters/query_domain"
+        - $ref: "#/components/parameters/authorization"
       responses:
-        '200':
+        "200":
           description: OK
           content:
             application/json:
@@ -2531,7 +2432,7 @@ paths:
                 description: TODO
                 properties:
                   acls:
-                    $ref: '#/components/schemas/ACLS'
+                    $ref: "#/components/schemas/ACLS"
                   hrefs:
                     type: array
                     items:
@@ -2550,20 +2451,18 @@ paths:
   # end /datasets/{id}/acls
 
   /datatypes/{id}/acls:
-
     get:
       tags:
         - ACLS
         - Datatype
       summary: List access lists on Datatype.
-#      description: Attributes sorted alphanumerially by name.
+      #      description: Attributes sorted alphanumerially by name.
       parameters:
-        - $ref: '#/components/parameters/path_datatype_uuid'
-        - $ref: '#/components/parameters/query_domain'
-        - $ref: '#/components/parameters/accept_json'
-        - $ref: '#/components/parameters/authorization'
+        - $ref: "#/components/parameters/path_datatype_uuid"
+        - $ref: "#/components/parameters/query_domain"
+        - $ref: "#/components/parameters/authorization"
       responses:
-        '200':
+        "200":
           description: OK
           content:
             application/json:
@@ -2572,7 +2471,7 @@ paths:
                 description: TODO
                 properties:
                   acls:
-                    $ref: '#/components/schemas/ACLS'
+                    $ref: "#/components/schemas/ACLS"
                   hrefs:
                     type: array
                     items:
@@ -2580,7 +2479,6 @@ paths:
                       properties:
                         href:
                           type: string
-                          format: uri
                           description: URL of resource
                         rel:
                           type: string
@@ -2590,5 +2488,4 @@ paths:
           description: Operation unsuccessful.
 
   # end /datatypes/{id}/acls
-
 #end paths


### PR DESCRIPTION
1. Removes the explicit definition of "Accept" header. This is done via the content-type. See [here](https://swagger.io/docs/specification/describing-parameters/).   

> Note: Header parameters named Accept, Content-Type and Authorization are not allowed. To describe these headers, use the corresponding OpenAPI keywords:

2. Changes some 'any' types defined as strings to the correct '{}' type.

3. Updates to open API 3.1. Mostly involves changing all the "example" fields to "examples"
4. Adds a Github Actions workflow to validate the specification (currently failing) 